### PR TITLE
README: copy/paste typo in 'check' documentation

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -56,7 +56,6 @@ Options for starting controller can be found in [controller.md](controller.md)
 
 - Annotation: `check` - activate pod check
 - Annotation: `check-interval` - interval between checks [`check` must be "enabled"]
-- use in format  `haproxy.org/load-balance: <algorithm> [ <arguments> ]`
 
 #### Ingress Class
 


### PR DESCRIPTION
check documentation was referring 'load-balance' related information