### PR TITLE
BUG/MAJOR: rate-limit: missing track rule

### DIFF
--- a/controller-rate-limiting.go
+++ b/controller-rate-limiting.go
@@ -127,6 +127,9 @@ func (c *HAProxyController) handleRateLimiting(transaction *models.Transaction, 
 			*httpRequest2,
 		}
 
+		c.cfg.TCPRequestsStatus = ADDED
+		c.cfg.HTTPRequestsStatus = ADDED
+
 	}
 
 	removeRateLimiting := func() {

--- a/controller-rate-limiting.go
+++ b/controller-rate-limiting.go
@@ -81,22 +81,17 @@ func (c *HAProxyController) handleRateLimiting(transaction *models.Transaction, 
 		Type:   "connection",
 		Action: "track-sc0 src table RateLimit",
 	}
-	tcpRequest2 := &models.TCPRequestRule{
-		ID:       &ID,
-		Type:     "connection",
-		Action:   "reject",
-		Cond:     "if",
-		CondTest: ratelimit_acl3.ACLName,
-	}
 	httpRequest1 := &models.HTTPRequestRule{
 		ID:       &ID,
 		Type:     "deny",
+		DenyStatus: 429,
 		Cond:     "if",
 		CondTest: fmt.Sprintf("%s %s", ratelimit_acl1.ACLName, ratelimit_acl2.ACLName),
 	}
 	httpRequest2 := &models.HTTPRequestRule{
 		ID:       &ID,
 		Type:     "deny",
+		DenyStatus: 429,
 		Cond:     "if",
 		CondTest: ratelimit_acl3.ACLName,
 	}
@@ -120,7 +115,6 @@ func (c *HAProxyController) handleRateLimiting(transaction *models.Transaction, 
 
 		c.cfg.TCPRequests[RATE_LIMIT] = []models.TCPRequestRule{
 			*tcpRequest1,
-			*tcpRequest2,
 		}
 		c.cfg.HTTPRequests[RATE_LIMIT] = []models.HTTPRequestRule{
 			*httpRequest1,

--- a/controller-requests.go
+++ b/controller-requests.go
@@ -97,16 +97,11 @@ func (c *HAProxyController) requestsTCPRefresh(transaction *models.Transaction) 
 
 	if len(c.cfg.TCPRequests[RATE_LIMIT]) > 0 {
 		request1 := &c.cfg.TCPRequests[RATE_LIMIT][0]
-		request2 := &c.cfg.TCPRequests[RATE_LIMIT][1]
 
 		err = nativeAPI.Configuration.CreateTCPRequestRule("frontend", FrontendHTTP, request1, transaction.ID, 0)
 		LogErr(err)
-		err = nativeAPI.Configuration.CreateTCPRequestRule("frontend", FrontendHTTP, request2, transaction.ID, 0)
-		LogErr(err)
 
 		err = nativeAPI.Configuration.CreateTCPRequestRule("frontend", FrontendHTTPS, request1, transaction.ID, 0)
-		LogErr(err)
-		err = nativeAPI.Configuration.CreateTCPRequestRule("frontend", FrontendHTTPS, request2, transaction.ID, 0)
 		LogErr(err)
 	}
 


### PR DESCRIPTION
In the rate-limit feature, the tracking is done through tcp-request
rules.
That said, when the configuration is generated, those rules are missing.
This patch fixes this issue.