### PR TITLE
Support logging via syslog-server annotation

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -88,7 +88,9 @@ func (c *HAProxyController) HAProxyInitialize() {
 	log.Println("Starting HAProxy with", HAProxyCFG)
 	if !c.osArgs.Test {
 		cmd := exec.Command("service", "haproxy", "start")
-		err = cmd.Run()
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err = cmd.Start()
 		if err != nil {
 			log.Println(err)
 		}
@@ -168,7 +170,9 @@ func (c *HAProxyController) HAProxyReload() error {
 	LogErr(err)
 	if !c.osArgs.Test {
 		cmd := exec.Command("service", "haproxy", "reload")
-		err = cmd.Run()
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err = cmd.Start()
 	} else {
 		err = nil
 		log.Println("HAProxy would be reloaded now")

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -28,6 +28,7 @@ Options for starting controller can be found in [controller.md](controller.md)
 | [ssl-certificate](#tls-secret) | string |  |  |:large_blue_circle:|:white_circle:|:white_circle:|
 | [ssl-redirect](#https) | "ON"/"OFF" | "ON" | [tls-secret](#tls-secret) |:large_blue_circle:|:white_circle:|:white_circle:|
 | [ssl-redirect-code](#https) | [301, 302, 303] | "302" | [tls-secret](#tls-secret) |:large_blue_circle:|:white_circle:|:white_circle:|
+| [syslog-server](#logging) | [syslog](#syslog-fields) | "log 127.0.0.1:514 local0 notice" |  |:large_blue_circle:|:white_circle:|:white_circle:|
 | [timeout-http-request](#timeouts) | [time](#time) | "5s" |  |:large_blue_circle:|:white_circle:|:white_circle:|
 | [timeout-check](#timeouts) | [time](#time) |  |  |:large_blue_circle:|:large_blue_circle:|:large_blue_circle:|
 | [timeout-connect](#timeouts) | [time](#time) | "5s" |  |:large_blue_circle:|:white_circle:|:white_circle:|
@@ -107,6 +108,34 @@ The number of requests a client can do per `rate-limit-interval` is **10**.
 - Annotation `servers-increment`- determines how much backend servers should we
         put in `maintenance` mode so controller can
         dynamically insert new pods without hitless reload
+
+#### Logging
+
+- Annotation `syslog-server`: Takes one or more syslog entries separated by "newlines".
+- Each syslog entry is a "comma" separated [syslog fields](#syslog-fields)
+- Example:
+  - Single syslog server:
+
+		syslog-server: address:127.0.0.1, port:514, facility:local0
+
+  - Multiple syslog servers:
+
+		syslog-server: |
+			address:127.0.0.1, port:514, facility:local0
+			address:192.168.1.1, port:514, facility:local1
+
+##### Syslog fields
+
+The following syslog fields can be used:
+- *address*:  Mandatory IP address where the syslog server is listening.
+- *port*:     Optional port number where the syslog server is listening (default 514).
+- *length*:   Optional maximum syslog line length.
+- *format*:   Optional syslog format.
+- *facility*: Mandatory, this can be one of the 24 syslog facilities.
+- *level*:    Optional level to filter outgoing messages.
+- *minlevel*: Optional minimum level.
+
+More information can be found in the official HAProxy [documentation](https://cbonte.github.io/haproxy-dconv/2.0/configuration.html#3.1-log)
 
 #### Timeouts
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -124,6 +124,10 @@ The number of requests a client can do per `rate-limit-interval` is **10**.
 			address:127.0.0.1, port:514, facility:local0
 			address:192.168.1.1, port:514, facility:local1
 
+- Logs can also be sent to stdout and viewed with `kubectl logs`:
+
+		syslog-server: address:stdout, format: raw, facility:daemon
+
 ##### Syslog fields
 
 The following syslog fields can be used:

--- a/fs/etc/haproxy/global.cfg
+++ b/fs/etc/haproxy/global.cfg
@@ -14,12 +14,13 @@ global
   stats socket /var/run/haproxy-runtime-api.sock level admin expose-fd listeners
   stats timeout 1m
   tune.ssl.default-dh-param 2048
+  log 127.0.0.1:514 local0 notice
   ssl-default-bind-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK
   ssl-default-bind-options no-sslv3 no-tls-tickets no-tlsv10
 
 defaults
   log global
-  log 127.0.0.1:514 local0 notice
+  option httplog
   option redispatch
   option dontlognull
   option http-keep-alive


### PR DESCRIPTION
These two commits make it possible to enable HAProxy logging via syslog-server annotation.