### PR TITLE
MINOR: move ConfigMap to controller namespace

### DIFF
--- a/deploy/haproxy-ingress.yaml
+++ b/deploy/haproxy-ingress.yaml
@@ -80,8 +80,8 @@ subjects:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: haproxy-configmap
-  namespace: default
+  name: haproxy
+  namespace: haproxy-controller
 data:
 
 ---
@@ -148,7 +148,7 @@ spec:
       - name: haproxy-ingress
         image: haproxytech/kubernetes-ingress
         args:
-          - --configmap=default/haproxy-configmap
+          - --configmap=haproxy-controller/haproxy
           - --default-backend-service=haproxy-controller/ingress-default-backend
         resources:
           requests:

--- a/documentation/controller.md
+++ b/documentation/controller.md
@@ -6,7 +6,6 @@ you can run image with arguments:
 
 - `--configmap`
   - mandatory, must be in format `namespace/name`
-  - default `default/haproxy-configmap`
 - `--default-backend-service`
   - must be in format `namespace/name`
 - `--default-ssl-certificate`

--- a/flags.go
+++ b/flags.go
@@ -33,7 +33,7 @@ type OSArgs struct {
 	Version               []bool         `short:"v" long:"version" description:"version"`
 	DefaultBackendService NamespaceValue `long:"default-backend-service" default:"" description:"default service to serve 404 page. If not specified HAProxy serves http 400"`
 	DefaultCertificate    NamespaceValue `long:"default-ssl-certificate" default:"" description:"secret name of the certificate"`
-	ConfigMap             NamespaceValue `long:"configmap" description:"configmap designated for HAProxy" default:"default/haproxy-configmap"`
+	ConfigMap             NamespaceValue `long:"configmap" description:"configmap designated for HAProxy" default:""`
 	KubeConfig            string         `long:"kubeconfig" default:"" description:"combined with -e. location of kube config file"`
 	NamespaceWhitelist    []string       `long:"namespace-whitelist" description:"whitelisted namespaces"`
 	NamespaceBlacklist    []string       `long:"namespace-blacklist" description:"blacklisted namespaces"`


### PR DESCRIPTION
ConfigMap should be located alongside the Deployment, it's common practice and eases uninstallation: you only need to delete the namespace.