### PR TITLE
MINOR: do not set default-ssl-certificate by default

### DIFF
--- a/deploy/haproxy-ingress.yaml
+++ b/deploy/haproxy-ingress.yaml
@@ -148,7 +148,6 @@ spec:
       - name: haproxy-ingress
         image: haproxytech/kubernetes-ingress
         args:
-          - --default-ssl-certificate=default/tls-secret
           - --configmap=default/haproxy-configmap
           - --default-backend-service=haproxy-controller/ingress-default-backend
         resources:


### PR DESCRIPTION
Default SSL certificate should not be enabled by default: it enables SSL redirect which gives errors when the secret is not there (very common setup, since a lot of people make use of cert-manager and don't have default certificate).