### PR TITLE
Code cleanup 

### DIFF
--- a/controller-backend-update.go
+++ b/controller-backend-update.go
@@ -1,0 +1,53 @@
+// Copyright 2019 HAProxy Technologies LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/haproxytech/models"
+)
+
+type backend models.Backend
+
+func (b *backend) updateBalance(data *StringW) error {
+	//TODO Balance proper usage
+	balanceAlg := &models.Balance{
+		Algorithm: data.Value,
+	}
+	if err := balanceAlg.Validate(nil); err != nil {
+		return err
+	}
+	b.Balance = balanceAlg
+	return nil
+}
+
+func (b *backend) updateCheckTimeout(data *StringW) error {
+	val, err := annotationConvertTimeToMS(*data)
+	if err != nil {
+		return err
+	}
+	b.CheckTimeout = &val
+	return nil
+}
+
+func (b *backend) updateForwardFor(data *StringW) error {
+	forwardFor := &models.Forwardfor{
+		Enabled: &data.Value,
+	}
+	if err := forwardFor.Validate(nil); err != nil {
+		return err
+	}
+	b.Forwardfor = forwardFor
+	return nil
+}

--- a/controller-haproxy.go
+++ b/controller-haproxy.go
@@ -59,7 +59,6 @@ func (c *HAProxyController) updateHAProxy() error {
 	needsReload = needsReload || reload
 
 	certsUsed := map[string]struct{}{}
-	backendsUsed := map[string]struct{}{}
 	for _, namespace := range c.cfg.Namespace {
 		if !namespace.Relevant {
 			continue
@@ -99,7 +98,7 @@ func (c *HAProxyController) updateHAProxy() error {
 					if path == nil {
 						continue
 					}
-					reload, err = c.handlePath(pathIndex, namespace, ingress, rule, path, backendsUsed)
+					reload, err = c.handlePath(pathIndex, namespace, ingress, rule, path)
 					needsReload = needsReload || reload
 					LogErr(err)
 					pathIndex++
@@ -144,7 +143,7 @@ func (c *HAProxyController) updateHAProxy() error {
 	LogErr(err)
 
 	//handle default service
-	reload, err = c.handleDefaultService(backendsUsed)
+	reload, err = c.handleDefaultService()
 	LogErr(err)
 	needsReload = needsReload || reload
 
@@ -188,7 +187,7 @@ func (c *HAProxyController) handleMaxconn(maxconn *int64, frontends ...string) e
 	return nil
 }
 
-func (c *HAProxyController) handleDefaultService(backendsUsed map[string]struct{}) (needsReload bool, err error) {
+func (c *HAProxyController) handleDefaultService() (needsReload bool, err error) {
 	needsReload = false
 	dsvcData, _ := GetValueFromAnnotations("default-backend-service")
 	dsvc := strings.Split(dsvcData.Value, "/")
@@ -209,5 +208,5 @@ func (c *HAProxyController) handleDefaultService(backendsUsed map[string]struct{
 		ServiceName: dsvc[1],
 		PathIndex:   -1,
 	}
-	return c.handlePath(0, namespace, ingress, nil, path, backendsUsed)
+	return c.handlePath(0, namespace, ingress, nil, path)
 }

--- a/controller.go
+++ b/controller.go
@@ -181,7 +181,7 @@ func (c *HAProxyController) HAProxyReload() error {
 	return err
 }
 
-func (c *HAProxyController) handlePath(index int, namespace *Namespace, ingress *Ingress, rule *IngressRule, path *IngressPath, backendsUsed map[string]struct{}) (needsReload bool, err error) {
+func (c *HAProxyController) handlePath(index int, namespace *Namespace, ingress *Ingress, rule *IngressRule, path *IngressPath) (needsReload bool, err error) {
 	needsReload = false
 	backendName, service, reload, err := c.handleService(index, namespace, ingress, rule, path)
 	needsReload = needsReload || reload
@@ -189,11 +189,6 @@ func (c *HAProxyController) handlePath(index int, namespace *Namespace, ingress 
 		return needsReload, err
 	}
 
-	_, alreadyConfigured := backendsUsed[backendName]
-	if alreadyConfigured {
-		return needsReload, nil
-	}
-	backendsUsed[backendName] = struct{}{}
 	endpoints, ok := namespace.Endpoints[service.Name]
 	if !ok {
 		log.Printf("Endpoint for service %s does not exists", service.Name)


### PR DESCRIPTION
This is a code cleanup in handlePath, handleService and handleBackendAnnotations.
This separates the backend annotations logic from handleService.
It also separates updating backend from handling annotations. Which makes it easier to add more annotations for the backend configuration.