### PR TITLE
BUG/MEDIUM: Delete transaction when there are no changes

### DIFF
--- a/controller-api.go
+++ b/controller-api.go
@@ -19,6 +19,9 @@ func (c *HAProxyController) apiStartTransaction() error {
 
 func (c *HAProxyController) apiCommitTransaction() error {
 	if !c.ActiveTransactionHasChanges {
+		if err := c.NativeAPI.Configuration.DeleteTransaction(c.ActiveTransaction); err != nil {
+			return err
+		}
 		return nil
 	}
 	_, err := c.NativeAPI.Configuration.CommitTransaction(c.ActiveTransaction)


### PR DESCRIPTION
Transaction should be deleted if there are no changes otherwise this
will result in memory leak because parsers are not freed.