### PR TITLE
make more reliable and scalable ingress 

### DIFF
--- a/deploy/haproxy-ingress.yaml
+++ b/deploy/haproxy-ingress.yaml
@@ -127,7 +127,7 @@ spec:
 
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   labels:
     run: haproxy-ingress
@@ -161,10 +161,13 @@ spec:
         ports:
         - name: http
           containerPort: 80
+          hostPort: 80
         - name: https
           containerPort: 443
+          hostPort: 443
         - name: stat
           containerPort: 1024
+          hostPort: 1024
         env:
         - name: POD_NAME
           valueFrom:


### PR DESCRIPTION
I think ingress container should be deployed as `DaemonSet` to be work distributed and scalable, if you use `Deployment` you should set replica manually and add some attribute for pod anti-affinity to distribute all replicas on all workers but I think `DaemonSet` is a better option for automatic scaling. and `DaemonSet` let us to use `hostPort` to expose HTTP over port 80 and HTTPS over port 443 and we aren`t limit to use port number from 30000 range. 