### PR TITLE
MINOR: Added annotation "server-ssl", sets downstream server "ssl verify none"

### DIFF
--- a/annotations.go
+++ b/annotations.go
@@ -144,4 +144,5 @@ var defaultAnnotationValues = MapStringW{
 	"timeout-http-keep-alive":   &StringW{Value: "1m"},
 	"whitelist":                 &StringW{Value: ""},
 	"whitelist-with-rate-limit": &StringW{Value: "false"},
+	"server-ssl":                &StringW{Value: "false"},
 }

--- a/annotations.go
+++ b/annotations.go
@@ -133,6 +133,7 @@ var defaultAnnotationValues = MapStringW{
 	"ssl-redirect":              &StringW{Value: "true"},
 	"ssl-redirect-code":         &StringW{Value: "302"},
 	"ssl-passthrough":           &StringW{Value: "false"},
+	"server-ssl":                &StringW{Value: "false"},
 	"servers-increment":         &StringW{Value: "42"},
 	"syslog-server":             &StringW{Value: "address:127.0.0.1, facility: local0, level: notice"},
 	"timeout-http-request":      &StringW{Value: "5s"},
@@ -144,5 +145,4 @@ var defaultAnnotationValues = MapStringW{
 	"timeout-http-keep-alive":   &StringW{Value: "1m"},
 	"whitelist":                 &StringW{Value: ""},
 	"whitelist-with-rate-limit": &StringW{Value: "false"},
-	"server-ssl":                &StringW{Value: "false"},
 }

--- a/controller-server-update.go
+++ b/controller-server-update.go
@@ -51,3 +51,18 @@ func (s *Server) updateMaxconn(data *StringW) error {
 	s.Maxconn = &maxconn
 	return nil
 }
+
+func (s *Server) updateServerSsl(data *StringW) error {
+	enabled, err := GetBoolValue(data.Value, "ssl")
+	if err != nil {
+		return err
+	}
+	if enabled {
+		s.Ssl = "enabled"
+		s.Verify = "none"
+	} else {
+		s.Ssl = "disabled"
+		s.Verify = ""
+	}
+	return nil
+}

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -25,6 +25,7 @@ Options for starting controller can be found in [controller.md](controller.md)
 | [rate-limit-expire](#rate-limit) | string | "30m" | [rate-limit](#rate-limit) |:large_blue_circle:|:white_circle:|:white_circle:|
 | [rate-limit-interval](#rate-limit) | string | "10s" | [rate-limit](#rate-limit) |:large_blue_circle:|:white_circle:|:white_circle:|
 | [rate-limit-size](#rate-limit) | string | "100k" | [rate-limit](#rate-limit) |:large_blue_circle:|:white_circle:|:white_circle:|
+| [server-ssl](#server-ssl) | ["true", "false"] | "false" |  |:large_blue_circle:|:white_circle:|:large_blue_circle:|
 | [servers-increment](#servers-slots-increment) | number | "42" |  |:large_blue_circle:|:white_circle:|:white_circle:|
 | [ssl-certificate](#tls-secret) | string |  |  |:large_blue_circle:|:white_circle:|:white_circle:|
 | [ssl-passthrough](#https) | ["true", "false"] | "false" |  |:large_blue_circle:|:large_blue_circle:|:large_blue_circle:|
@@ -114,6 +115,14 @@ The number of requests a client can do per `rate-limit-interval` is **10**.
 - Annotation: `rate-limit-size`
   - number of ip entries in table
 
+#### Server ssl
+
+- Annotation `server-ssl`- Use ssl for backend servers.
+        This doesn't verify backend servers.
+- Example:
+ 
+		server server1 127.0.0.1:443 ssl verify none        
+        
 #### Servers slots increment
 
 - Annotation `servers-increment`- determines how much backend servers should we


### PR DESCRIPTION
Added annotation "server-ssl", this sets downstream server "ssl verify none" if enable, default is disable.