### PR TITLE
MINOR: Send X-Forwarded-Proto to HTTP backends for TLS clients.

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -26,8 +26,6 @@ const (
 	RATE_LIMIT = "rate-limit"
 	//nolint
 	HTTP_REDIRECT = "http-redirect"
-	//nolint
-	X_FORWARDED_PROTO = "x-forwarded-proto"
 )
 
 //Configuration represents k8s state
@@ -101,9 +99,6 @@ func (c *Configuration) Init(osArgs OSArgs, api *clientnative.HAProxyClient) {
 
 	c.HTTPRequests = map[string][]models.HTTPRequestRule{}
 	c.HTTPRequests[RATE_LIMIT] = []models.HTTPRequestRule{}
-
-	c.HTTPRequests = map[string][]models.HTTPRequestRule{}
-	c.HTTPRequests[X_FORWARDED_PROTO] = []models.HTTPRequestRule{}
 	c.HTTPRequestsStatus = EMPTY
 
 	c.TCPRequests = map[string][]models.TCPRequestRule{}

--- a/configuration.go
+++ b/configuration.go
@@ -26,6 +26,8 @@ const (
 	RATE_LIMIT = "rate-limit"
 	//nolint
 	HTTP_REDIRECT = "http-redirect"
+	//nolint
+	X_FORWARDED_PROTO = "x-forwarded-proto"
 )
 
 //Configuration represents k8s state
@@ -99,6 +101,9 @@ func (c *Configuration) Init(osArgs OSArgs, api *clientnative.HAProxyClient) {
 
 	c.HTTPRequests = map[string][]models.HTTPRequestRule{}
 	c.HTTPRequests[RATE_LIMIT] = []models.HTTPRequestRule{}
+
+	c.HTTPRequests = map[string][]models.HTTPRequestRule{}
+	c.HTTPRequests[X_FORWARDED_PROTO] = []models.HTTPRequestRule{}
 	c.HTTPRequestsStatus = EMPTY
 
 	c.TCPRequests = map[string][]models.TCPRequestRule{}

--- a/controller-requests.go
+++ b/controller-requests.go
@@ -53,7 +53,8 @@ func (c *HAProxyController) RequestsHTTPRefresh() (needsReload bool, err error) 
 		Cond:       "if",
 		CondTest:   "{ ssl_fc }",
 	}
-	c.frontendHTTPRequestRuleCreate(FrontendHTTPS, xforwardedprotoRule)
+	err = c.frontendHTTPRequestRuleCreate(FrontendHTTPS, xforwardedprotoRule)
+        LogErr(err)
 
 	sortedList := []string{}
 	exclude := map[string]struct{}{

--- a/controller-requests.go
+++ b/controller-requests.go
@@ -58,9 +58,8 @@ func (c *HAProxyController) RequestsHTTPRefresh() (needsReload bool, err error) 
 
 	sortedList := []string{}
 	exclude := map[string]struct{}{
-		HTTP_REDIRECT:     struct{}{},
-		RATE_LIMIT:        struct{}{},
-		X_FORWARDED_PROTO: struct{}{},
+		HTTP_REDIRECT: struct{}{},
+		RATE_LIMIT:    struct{}{},
 	}
 	for name := range c.cfg.HTTPRequests {
 		_, excluding := exclude[name]

--- a/fs/etc/haproxy/haproxy.cfg
+++ b/fs/etc/haproxy/haproxy.cfg
@@ -38,6 +38,7 @@ frontend https
   mode http
   bind 0.0.0.0:443 name bind_1
   bind :::443 v4v6 name bind_2
+  http-request set-header X-Forwarded-Proto https if { ssl_fc }
   default_backend default_backend
 
 frontend http   


### PR DESCRIPTION
Hi folks,

Thanks for taking the time to look at this, my apologies if I've misunderstood something or messed something up - this is my first PR here.

This PR addresses #124 by setting the `X-Forwarded-Proto` header with a value of `https` if the incoming request was received over TLS.

I wasn't immediately sure about how to ensure this configuration stayed constant, so I tried to follow what looked like existing patterns. If desired, I'm sure this behaviour could be configurable as opposed to on by default with no option to disable. I'd be happy to discuss it.

Most of all, I'd be very grateful for feedback on how I can improve the code here, and/or whether there's a better approach. Some pointers for where to add tests would be appreciated too.

Thanks in advance for your time.