### PR TITLE
BUG/MEDIUM: Process only ingress objects which ingress.class strictly matches the controller --ingress.class CLI arg.

### DIFF
--- a/controller/annotations.go
+++ b/controller/annotations.go
@@ -127,7 +127,6 @@ func SetDefaultAnnotation(annotation, value string) {
 }
 
 var defaultAnnotationValues = MapStringW{
-	"ingress.class":           &StringW{Value: ""},
 	"check":                   &StringW{Value: "true"},
 	"cookie-indirect":         &StringW{Value: "true"},
 	"cookie-nocache":          &StringW{Value: "true"},

--- a/controller/configuration.go
+++ b/controller/configuration.go
@@ -32,6 +32,7 @@ type NamespacesWatch struct {
 type Configuration struct {
 	Namespace              map[string]*Namespace
 	NamespacesAccess       NamespacesWatch
+	IngressClass           string
 	ConfigMap              *ConfigMap
 	ConfigMapTCPServices   *ConfigMap
 	PublishService         *Service
@@ -74,6 +75,9 @@ func (c *Configuration) Init(osArgs utils.OSArgs, mapDir string) {
 	for _, namespace := range osArgs.NamespaceBlacklist {
 		c.NamespacesAccess.Blacklist[namespace] = struct{}{}
 	}
+
+	c.IngressClass = osArgs.IngressClass
+
 	parts := strings.Split(osArgs.PublishService, "/")
 	if len(parts) == 2 {
 		c.PublishService = &Service{

--- a/controller/haproxy.go
+++ b/controller/haproxy.go
@@ -56,10 +56,6 @@ func (c *HAProxyController) updateHAProxy() error {
 			continue
 		}
 		for _, ingress := range namespace.Ingresses {
-			annClass, _ := GetValueFromAnnotations("ingress.class", ingress.Annotations) // default is ""
-			if annClass.Value != "" && annClass.Value != c.osArgs.IngressClass {
-				continue
-			}
 			if c.cfg.PublishService != nil && ingress.Status != DELETED {
 				utils.LogErr(c.k8s.UpdateIngressStatus(ingress, c.cfg.PublishService))
 			}

--- a/controller/utils/flags.go
+++ b/controller/utils/flags.go
@@ -41,6 +41,6 @@ type OSArgs struct {
 	OutOfCluster          bool           `short:"e" description:"use as out of cluster controller NOTE: experimantal"`
 	Test                  bool           `short:"t" description:"simulate running HAProxy"`
 	Help                  []bool         `short:"h" long:"help" description:"show this help message"`
-	IngressClass          string         `long:"ingress.class" default:"haproxy" description:"ingress.class to monitor in multiple controllers environment"`
+	IngressClass          string         `long:"ingress.class" default:"" description:"ingress.class to monitor in multiple controllers environment"`
 	PublishService        string         `long:"publish-service" default:"" description:"Takes the form namespace/name. The controller mirrors the address of this service's endpoints to the load-balancer status of all Ingress objects it satisfies"`
 }


### PR DESCRIPTION
In addition to strictly matching ingress.class, controller will dynamically
drop or take into account ingress objects depending on their
ingress.class annotation.