### PR TITLE
MAJOR: Add weights via pod object annotations

### DIFF
--- a/controller/configuration.go
+++ b/controller/configuration.go
@@ -46,6 +46,7 @@ type Configuration struct {
 	RateLimitingEnabled    bool
 	HTTPS                  bool
 	SSLPassthrough         bool
+	Pods                   map[string]*Pod
 }
 
 func (c *Configuration) IsRelevantNamespace(namespace string) bool {
@@ -109,6 +110,7 @@ func (c *Configuration) Init(osArgs utils.OSArgs, mapDir string) {
 	for _, frontend := range []string{FrontendHTTP, FrontendHTTPS, FrontendSSL} {
 		c.BackendSwitchingRules[frontend] = UseBackendRules{}
 	}
+	c.Pods = make(map[string]*Pod)
 }
 
 //GetNamespace returns Namespace. Creates one if not existing
@@ -216,6 +218,15 @@ func (c *Configuration) Clean() {
 			default:
 				data.Status = EMPTY
 			}
+		}
+	}
+	for _, data := range c.Pods {
+		data.Annotations.Clean()
+		switch data.Status {
+		case DELETED:
+			delete(c.Pods, data.UID)
+		default:
+			data.Status = EMPTY
 		}
 	}
 	c.ConfigMap.Annotations.Clean()

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -255,11 +255,7 @@ func (c *HAProxyController) handleEndpointIP(namespace *Namespace, ingress *Ingr
 				}
 			}
 			switch podStatus {
-			case MODIFIED:
-				fallthrough
-			case DELETED:
-				fallthrough
-			case ADDED:
+			case MODIFIED, DELETED, ADDED:
 				needReload = true
 			}
 		}
@@ -284,11 +280,7 @@ func (c *HAProxyController) handleEndpointIP(namespace *Namespace, ingress *Ingr
 	}
 	if status == EMPTY {
 		switch podStatus {
-		case MODIFIED:
-			fallthrough
-		case DELETED:
-			fallthrough
-		case ADDED:
+		case MODIFIED, DELETED, ADDED:
 			status = MODIFIED
 		}
 	}

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -26,6 +26,7 @@ const (
 	NAMESPACE SyncType = "NAMESPACE"
 	SERVICE   SyncType = "SERVICE"
 	SECRET    SyncType = "SECRET"
+	POD       SyncType = "POD"
 )
 
 //SyncDataEvent represents converted k8s received message

--- a/controller/types-equal.go
+++ b/controller/types-equal.go
@@ -159,6 +159,23 @@ func (a *Ingress) Equal(b *Ingress) bool {
 	return a.Annotations.Equal(b.Annotations)
 }
 
+//Equal checks if Pods are equal
+func (a *Pod) Equal(b *Pod) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	if a.Name != b.Name {
+		return false
+	}
+	if a.UID != b.UID {
+		return false
+	}
+	if a.Namespace != b.Namespace {
+		return false
+	}
+	return a.Annotations.Equal(b.Annotations)
+}
+
 //Equal compares two services, ignores statuses and old values
 func (a *Service) Equal(b *Service) bool {
 	if a == nil || b == nil {

--- a/controller/types.go
+++ b/controller/types.go
@@ -15,6 +15,7 @@
 package controller
 
 import (
+	v1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 )
 
@@ -45,6 +46,7 @@ type EndpointIP struct {
 	HAProxyName string
 	Disabled    bool
 	Status      Status
+	TargetRef   v1.ObjectReference
 }
 
 type EndpointPort struct {
@@ -64,6 +66,15 @@ type Endpoints struct {
 	BackendName string
 	Ports       *EndpointPorts
 	Addresses   *EndpointIPs
+	Status      Status
+}
+
+//Pod is for resolving pods to get the weight annotation
+type Pod struct {
+	Namespace   string
+	Name        string
+	UID         string
+	Annotations MapStringW
 	Status      Status
 }
 

--- a/controller/utils/flags.go
+++ b/controller/utils/flags.go
@@ -43,4 +43,5 @@ type OSArgs struct {
 	Help                  []bool         `short:"h" long:"help" description:"show this help message"`
 	IngressClass          string         `long:"ingress.class" default:"" description:"ingress.class to monitor in multiple controllers environment"`
 	PublishService        string         `long:"publish-service" default:"" description:"Takes the form namespace/name. The controller mirrors the address of this service's endpoints to the load-balancer status of all Ingress objects it satisfies"`
+	DefaultWeight         int64          `long:"default-weight" default:"128" description:"The default weight of backend servers in case no weight is specified explicitly for the pod"`
 }

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -48,6 +48,11 @@ Options for starting controller can be found in [controller.md](controller.md)
 | [timeout-tunnel](#timeouts) | [time](#time) | "1h" |  |:large_blue_circle:|:white_circle:|:white_circle:|
 | [whitelist](#whitelist) | [IPs or CIDRs](#whitelist) | "" |  |:large_blue_circle:|:large_blue_circle:|:white_circle:|
 
+#### Object specific annotations
+| Annotation | Type | Default | Dependencies | Object |
+| - |:-:|:-:|:-:|:-:|
+| [weight](#traffic distribution) | number 0-256 | set via `--default-weight` parameter or 128 || Pod |
+
 > :information_source: Annotations have hierarchy: `default` <- `Configmap` <- `Ingress` <- `Service`
 >
 > Service annotations have highest priority. If they are not defined, controller goes one level up until it finds value.
@@ -253,6 +258,12 @@ More information can be found in the official HAProxy [documentation](https://cb
 
 - Annotation: `forwarded-for`
 - by default enabled, can be disabled per service or globally
+
+#### Traffic distribution
+- Annotation: `weight`
+  - Set on the pod, this annotation can be used to set the weight of the pod in the backend configuration in order to control the amount of traffic these pods receive relative to other pods.
+  - The default weight for all other endpoints or pods that don't have to specific annotation can be set via the controller command line parameter `--default-weight` and defaults to 128 if not set. 
+  - More information can be found in the official HAProxy [documentation](https://cbonte.github.io/haproxy-dconv/2.0/configuration.html#5-weight) 
 
 ### Secrets
 

--- a/documentation/controller.md
+++ b/documentation/controller.md
@@ -30,6 +30,9 @@ you can run image with arguments:
 - `--default-ssl-certificate`
   - optional, must be in format `namespace/name`
   - default: ""
+- `--default-weight`
+  - default: 128
+  - optional, defines the weight for endpoints that don't have an explicit weight defined
 - `--ingress.class`
   - default: ""
   - class of ingress object to monitor in multiple controllers environment


### PR DESCRIPTION
This commit adds support for weights for backend endpoints via pod
annotations. By adding a haproxy.org/weight annotation to a pod you can
specify an explicit weight whenever that pod is being used in an
endpoint as long as the TargetRef was added properly (usually
automatically via services). Additionally, the default weight can be
specified via the new --default-weight parameter.