### PR TITLE
FEATURE/MEDIUM: Add response-set-header config

### DIFF
--- a/controller/api.go
+++ b/controller/api.go
@@ -165,9 +165,22 @@ func (c *HAProxyController) frontendHTTPRequestRuleDeleteAll(frontend string) {
 	}
 }
 
+func (c *HAProxyController) frontendHTTPResponseRuleDeleteAll(frontend string) {
+	c.ActiveTransactionHasChanges = true
+	var err error
+	for err == nil {
+		err = c.NativeAPI.Configuration.DeleteHTTPResponseRule(0, "frontend", frontend, c.ActiveTransaction, 0)
+	}
+}
+
 func (c *HAProxyController) frontendHTTPRequestRuleCreate(frontend string, rule models.HTTPRequestRule) error {
 	c.ActiveTransactionHasChanges = true
 	return c.NativeAPI.Configuration.CreateHTTPRequestRule("frontend", frontend, &rule, c.ActiveTransaction, 0)
+}
+
+func (c *HAProxyController) frontendHTTPResponseRuleCreate(frontend string, rule models.HTTPResponseRule) error {
+	c.ActiveTransactionHasChanges = true
+	return c.NativeAPI.Configuration.CreateHTTPResponseRule("frontend", frontend, &rule, c.ActiveTransaction, 0)
 }
 
 func (c *HAProxyController) frontendTCPRequestRuleDeleteAll(frontend string) {

--- a/controller/configuration.go
+++ b/controller/configuration.go
@@ -37,7 +37,7 @@ type Configuration struct {
 	ConfigMapTCPServices   *ConfigMap
 	PublishService         *Service
 	MapFiles               haproxy.Maps
-	FrontendHTTPRules      map[Rule]FrontendHTTPReqs
+	FrontendHTTPReqRules   map[Rule]FrontendHTTPReqs
 	FrontendTCPRules       map[Rule]FrontendTCPReqs
 	FrontendRulesStatus    map[Mode]Status
 	BackendSwitchingRules  map[string]UseBackendRules
@@ -89,9 +89,9 @@ func (c *Configuration) Init(osArgs utils.OSArgs, mapDir string) {
 
 	c.Namespace = make(map[string]*Namespace)
 
-	c.FrontendHTTPRules = make(map[Rule]FrontendHTTPReqs)
+	c.FrontendHTTPReqRules = make(map[Rule]FrontendHTTPReqs)
 	for _, rule := range []Rule{BLACKLIST, SSL_REDIRECT, RATE_LIMIT, REQUEST_CAPTURE, REQUEST_SET_HEADER, WHITELIST} {
-		c.FrontendHTTPRules[rule] = make(map[uint64]models.HTTPRequestRule)
+		c.FrontendHTTPReqRules[rule] = make(map[uint64]models.HTTPRequestRule)
 	}
 	c.FrontendTCPRules = make(map[Rule]FrontendTCPReqs)
 	for _, rule := range []Rule{BLACKLIST, REQUEST_CAPTURE, PROXY_PROTOCOL, WHITELIST} {
@@ -238,8 +238,8 @@ func (c *Configuration) Clean() {
 		}
 	}
 	c.MapFiles.Clean()
-	for rule := range c.FrontendHTTPRules {
-		c.FrontendHTTPRules[rule] = make(map[uint64]models.HTTPRequestRule)
+	for rule := range c.FrontendHTTPReqRules {
+		c.FrontendHTTPReqRules[rule] = make(map[uint64]models.HTTPRequestRule)
 	}
 	for rule := range c.FrontendTCPRules {
 		c.FrontendTCPRules[rule] = make(map[uint64]models.TCPRequestRule)

--- a/controller/configuration.go
+++ b/controller/configuration.go
@@ -38,6 +38,7 @@ type Configuration struct {
 	PublishService         *Service
 	MapFiles               haproxy.Maps
 	FrontendHTTPReqRules   map[Rule]FrontendHTTPReqs
+	FrontendHTTPRspRules   map[Rule]FrontendHTTPRsps
 	FrontendTCPRules       map[Rule]FrontendTCPReqs
 	FrontendRulesStatus    map[Mode]Status
 	BackendSwitchingRules  map[string]UseBackendRules
@@ -92,6 +93,10 @@ func (c *Configuration) Init(osArgs utils.OSArgs, mapDir string) {
 	c.FrontendHTTPReqRules = make(map[Rule]FrontendHTTPReqs)
 	for _, rule := range []Rule{BLACKLIST, SSL_REDIRECT, RATE_LIMIT, REQUEST_CAPTURE, REQUEST_SET_HEADER, WHITELIST} {
 		c.FrontendHTTPReqRules[rule] = make(map[uint64]models.HTTPRequestRule)
+	}
+	c.FrontendHTTPRspRules = make(map[Rule]FrontendHTTPRsps)
+	for _, rule := range []Rule{RESPONSE_SET_HEADER} {
+		c.FrontendHTTPRspRules[rule] = make(map[uint64]models.HTTPResponseRule)
 	}
 	c.FrontendTCPRules = make(map[Rule]FrontendTCPReqs)
 	for _, rule := range []Rule{BLACKLIST, REQUEST_CAPTURE, PROXY_PROTOCOL, WHITELIST} {
@@ -240,6 +245,9 @@ func (c *Configuration) Clean() {
 	c.MapFiles.Clean()
 	for rule := range c.FrontendHTTPReqRules {
 		c.FrontendHTTPReqRules[rule] = make(map[uint64]models.HTTPRequestRule)
+	}
+	for rule := range c.FrontendHTTPRspRules {
+		c.FrontendHTTPRspRules[rule] = make(map[uint64]models.HTTPResponseRule)
 	}
 	for rule := range c.FrontendTCPRules {
 		c.FrontendTCPRules[rule] = make(map[uint64]models.TCPRequestRule)

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -144,6 +144,7 @@ func (c *HAProxyController) updateHAProxy() error {
 			utils.LogErr(c.handleRateLimiting(ingress))
 			utils.LogErr(c.handleRequestCapture(ingress))
 			utils.LogErr(c.handleRequestSetHdr(ingress))
+			utils.LogErr(c.handleResponseSetHdr(ingress))
 			utils.LogErr(c.handleBlacklisting(ingress))
 			utils.LogErr(c.handleWhitelisting(ingress))
 			utils.LogErr(c.handleHTTPRedirect(ingress))
@@ -159,6 +160,8 @@ func (c *HAProxyController) updateHAProxy() error {
 	reload = reload || r
 
 	reload = c.FrontendHTTPReqsRefresh() || reload
+
+	reload = c.FrontendHTTPRspsRefresh() || reload
 
 	reload = c.FrontendTCPreqsRefresh() || reload
 

--- a/controller/requests.go
+++ b/controller/requests.go
@@ -75,18 +75,18 @@ func (c *HAProxyController) FrontendHTTPReqsRefresh() (reload bool) {
 	}
 	utils.LogErr(c.frontendHTTPRequestRuleCreate(FrontendHTTPS, xforwardedprotoRule))
 	// SSL_REDIRECT
-	for key, httpRule := range c.cfg.FrontendHTTPRules[SSL_REDIRECT] {
+	for key, httpRule := range c.cfg.FrontendHTTPReqRules[SSL_REDIRECT] {
 		c.cfg.MapFiles.Modified(key)
 		utils.LogErr(c.frontendHTTPRequestRuleCreate(FrontendHTTP, httpRule))
 	}
 	for _, frontend := range []string{FrontendHTTP, FrontendHTTPS} {
 		// REQUEST_SET_HEADER
-		for key, httpRule := range c.cfg.FrontendHTTPRules[REQUEST_SET_HEADER] {
+		for key, httpRule := range c.cfg.FrontendHTTPReqRules[REQUEST_SET_HEADER] {
 			c.cfg.MapFiles.Modified(key)
 			utils.LogErr(c.frontendHTTPRequestRuleCreate(frontend, httpRule))
 		}
 		// REQUEST_CAPTURE
-		for key, httpRule := range c.cfg.FrontendHTTPRules[REQUEST_CAPTURE] {
+		for key, httpRule := range c.cfg.FrontendHTTPReqRules[REQUEST_CAPTURE] {
 			c.cfg.MapFiles.Modified(key)
 			utils.LogErr(c.frontendHTTPRequestRuleCreate(frontend, httpRule))
 		}
@@ -114,16 +114,16 @@ func (c *HAProxyController) FrontendHTTPReqsRefresh() (reload bool) {
 				utils.LogErr(err)
 			}
 		}
-		for key, httpRule := range c.cfg.FrontendHTTPRules[RATE_LIMIT] {
+		for key, httpRule := range c.cfg.FrontendHTTPReqRules[RATE_LIMIT] {
 			c.cfg.MapFiles.Modified(key)
 			utils.LogErr(c.frontendHTTPRequestRuleCreate(frontend, httpRule))
 		}
 		// BLACKLIST
-		for _, httpRule := range c.cfg.FrontendHTTPRules[BLACKLIST] {
+		for _, httpRule := range c.cfg.FrontendHTTPReqRules[BLACKLIST] {
 			utils.LogErr(c.frontendHTTPRequestRuleCreate(frontend, httpRule))
 		}
 		// WHITELIST
-		for _, httpRule := range c.cfg.FrontendHTTPRules[WHITELIST] {
+		for _, httpRule := range c.cfg.FrontendHTTPReqRules[WHITELIST] {
 			utils.LogErr(c.frontendHTTPRequestRuleCreate(frontend, httpRule))
 		}
 	}

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -32,6 +32,7 @@ Options for starting controller can be found in [controller.md](controller.md)
 | [request-capture](#request-capture) | [sample expression](#sample-expression) |  |  |:large_blue_circle:|:large_blue_circle:|:white_circle:|
 | [request-capture-len](#request-capture) | number | 128 |  |:large_blue_circle:|:large_blue_circle:|:white_circle:|
 | [request-set-header](#request-set-header) | string |  |  |:large_blue_circle:|:large_blue_circle:|:white_circle:|
+| [response-set-header](#response-set-header) | string |  |  |:large_blue_circle:|:large_blue_circle:|:white_circle:|
 | [server-ssl](#server-ssl) | ["true", "false"] | "false" |  |:large_blue_circle:|:large_blue_circle:|:large_blue_circle:|
 | [set-host](#set-host) | string |  |  |:white_circle:|:large_blue_circle:|:large_blue_circle:|
 | [servers-increment](#servers-slots-increment) | number | "42" |  |:large_blue_circle:|:white_circle:|:white_circle:|
@@ -192,6 +193,31 @@ More information can be found in the official HAProxy [documentation](https://cb
           So in the case you want to change the Host header this will impact
           HAProxy decision on which service/backend to use (based on matching Host against ingress rules).
           In order to set the Host header after service selection, use [set-host](#set-host) annotation.
+
+#### Response Set Header
+- Annotation `response-set-header`
+  - Single value:
+    - Usage:
+    ```
+    response-set-header: <Header> <value>
+    ```
+    - Example:
+    ```
+    response-set-header: Ingress-id Ienai6ohdoh9
+    ```
+  - Multiple values:
+    - Usage:
+    ```
+    response-set-header: |
+      <Header> <value>
+      <Header> <value>
+    ```
+    - Example:
+    ```
+    response-set-header: |
+      Strict-Transport-Security "max-age=31536000"
+      Cache-Control "no-store,no-cache,private"
+    ```
 
 #### Set Host
 - Annotation `set-host`


### PR DESCRIPTION
Fixes #79.

Duplicates the mechanism for `request-set-header` to set response headers, also renamed the `FrontendHTTPRules` map for clarity.

I've tested that the functionality behaves as intended at least in terms of setting headers for the appropriate hostnames given ingress annotations or configmap entries. A pre-built image is available publicly on Dockerhub at [`easkay/haproxy-ingress:response_set_header`](https://hub.docker.com/repository/docker/easkay/kubernetes-ingress).

Thanks in advance for your time, and feedback is much appreciated.