### PR TITLE
Providing sync-period as CLI flag

### DIFF
--- a/controller/configuration.go
+++ b/controller/configuration.go
@@ -59,7 +59,7 @@ func (c *Configuration) IsRelevantNamespace(namespace string) bool {
 	return !ok
 }
 
-//Init itialize configuration
+//Init initialize configuration
 func (c *Configuration) Init(osArgs utils.OSArgs, mapDir string) {
 
 	c.NamespacesAccess = NamespacesWatch{

--- a/controller/utils/flags.go
+++ b/controller/utils/flags.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 )
 
 //NamespaceValue used to automatically distinct namespace/name string
@@ -43,4 +44,5 @@ type OSArgs struct {
 	Help                  []bool         `short:"h" long:"help" description:"show this help message"`
 	IngressClass          string         `long:"ingress.class" default:"" description:"ingress.class to monitor in multiple controllers environment"`
 	PublishService        string         `long:"publish-service" default:"" description:"Takes the form namespace/name. The controller mirrors the address of this service's endpoints to the load-balancer status of all Ingress objects it satisfies"`
+	SyncPeriod            time.Duration  `long:"sync-period" default:"5s" description:"Sets the synchronization period at which the controller executes the configuration sync"`
 }

--- a/documentation/controller.md
+++ b/documentation/controller.md
@@ -51,3 +51,8 @@ you can run image with arguments:
 - `--publish-service`
   - optional, must be in fromat `namespace/name`
   - The controller mirrors the address of the service's endpoints to the load-balancer status of all Ingress objects it satisfies.
+
+- `--sync-period`
+  - optional (must adhere to [`time.Duration`](https://golang.org/pkg/time/#ParseDuration) format),
+    sets the synchronization period at which the controller executes the configuration sync
+  - default value to `5s` (_5 seconds_)

--- a/documentation/controller.md
+++ b/documentation/controller.md
@@ -46,10 +46,10 @@ you can run image with arguments:
 
 - `--namespace-blacklist`
   - optional, if listed selected namespaces will be excluded
-  - usage: same as whitellisting
+  - usage: same as whitelisting
 
 - `--publish-service`
-  - optional, must be in fromat `namespace/name`
+  - optional, must be in format `namespace/name`
   - The controller mirrors the address of the service's endpoints to the load-balancer status of all Ingress objects it satisfies.
 
 - `--sync-period`

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ func main() {
 	defaultCertificate := fmt.Sprintf("%s/%s", osArgs.DefaultBackendService.Namespace, osArgs.DefaultCertificate.Name)
 	c.SetDefaultAnnotation("default-backend-service", defaultBackendSvc)
 	c.SetDefaultAnnotation("ssl-certificate", defaultCertificate)
+	c.SetDefaultAnnotation("sync-period", osArgs.SyncPeriod.String())
 
 	if len(osArgs.Version) > 0 {
 		fmt.Printf("HAProxy Ingress Controller %s %s%s\n\n", GitTag, GitCommit, GitDirty)
@@ -76,6 +77,7 @@ func main() {
 	log.Printf("Publish service: %s\n", osArgs.PublishService)
 	log.Printf("Default backend service: %s\n", defaultBackendSvc)
 	log.Printf("Default ssl certificate: %s\n", defaultCertificate)
+	log.Printf("Controller sync period: %s\n", osArgs.SyncPeriod.String())
 	if osArgs.ConfigMapTCPServices.Name != "" {
 		log.Printf("TCP Services defined in %s/%s\n", osArgs.ConfigMapTCPServices.Namespace, osArgs.ConfigMapTCPServices.Name)
 	}


### PR DESCRIPTION
Closes #182.

Implementing as CLI flag: `--sync-period=1s`: allowed time unit are the ones provided by Go's `time.Duration` package.

The default value is still set at `5s`, so no breaking change is expected.

In the case of non-well-formed unit, `flag.Parse` exits with code `1` and following error:

```
2020/04/27 08:10:21 invalid argument for flag `--sync-period' (expected time.Duration): time: unknown unit typo in duration 1typo
```