### PR TITLE
MINOR: Ignore the port part when matching for HTTP redirects

### DIFF
--- a/controller/frontend-annotations.go
+++ b/controller/frontend-annotations.go
@@ -142,7 +142,8 @@ func (c *HAProxyController) handleHTTPRedirect(ingress *Ingress) error {
 		RedirValue: "https",
 		RedirType:  "scheme",
 		Cond:       "if",
-		CondTest:   fmt.Sprintf("{ req.hdr(Host) -f %s } !{ ssl_fc }", mapFile),
+		//TODO: provide option to do strict host matching
+		CondTest:   fmt.Sprintf("{ req.hdr(host),field(1,:) -f %s } !{ ssl_fc }", mapFile),
 	}
 	c.cfg.FrontendHTTPReqRules[SSL_REDIRECT][key] = httpRule
 


### PR DESCRIPTION
Similarly to: https://github.com/haproxytech/kubernetes-ingress/commit/aac95d5fef1377b26df9cde6d49efeb0b5a13001