### PR TITLE
MINOR: removing replicas from DaemonSet

### DIFF
--- a/deploy/haproxy-ingress-daemonset.yaml
+++ b/deploy/haproxy-ingress-daemonset.yaml
@@ -134,7 +134,6 @@ metadata:
   name: haproxy-ingress
   namespace: haproxy-controller
 spec:
-  replicas: 1
   selector:
     matchLabels:
       run: haproxy-ingress


### PR DESCRIPTION
Using replicas in DaemonSet kind will throw a validation error in latest k8s versions.
``` js
ValidationError(DaemonSet.spec): unknown field "replicas" in io.k8s.api.apps.v1.DaemonSetSpec;
```