### PR TITLE
BUG/MEDIUM: Fix unmatched acl in response-set-header

### DIFF
--- a/controller/frontend-annotations.go
+++ b/controller/frontend-annotations.go
@@ -418,7 +418,7 @@ func (c *HAProxyController) handleResponseSetHdr(ingress *Ingress) error {
 			HdrName:   parts[0],
 			HdrFormat: parts[1],
 			Cond:      "if",
-			CondTest:  fmt.Sprintf("{ req.hdr(Host) -f %s }", mapFile),
+			CondTest:  fmt.Sprintf("{ var(txn.Host) -f %s }", mapFile),
 		}
 		c.cfg.FrontendHTTPRspRules[RESPONSE_SET_HEADER][key] = httpRule
 	}

--- a/controller/requests.go
+++ b/controller/requests.go
@@ -122,6 +122,15 @@ func (c *HAProxyController) FrontendHTTPReqsRefresh() (reload bool) {
 			VarExpr:  "base",
 		}
 		c.Logger.Error(c.Client.FrontendHTTPRequestRuleCreate(frontend, setVarBaseRule))
+		// STATIC: SET_VARIABLE txn.Host (to use in http-response acls)
+		setVarBaseRule = models.HTTPRequestRule{
+			Index:    utils.PtrInt64(0),
+			Type:     "set-var",
+			VarName:  "Host",
+			VarScope: "txn",
+			VarExpr:  "req.hdr(Host)",
+		}
+		c.Logger.Error(c.Client.FrontendHTTPRequestRuleCreate(frontend, setVarBaseRule))
 		// RATE_LIMIT
 		for tableName, table := range rateLimitTables {
 			_, err := c.Client.BackendGet(tableName)

--- a/fs/etc/haproxy/haproxy.cfg
+++ b/fs/etc/haproxy/haproxy.cfg
@@ -39,6 +39,7 @@ frontend https
   bind 0.0.0.0:443 name bind_1
   bind :::443 v4v6 name bind_2
   http-request set-var(txn.Base) base
+  http-request set-var(txn.Host) req.hdr(Host)
   http-request set-header X-Forwarded-Proto https if { ssl_fc }
   default_backend default_backend
 
@@ -46,6 +47,7 @@ frontend http
   bind 0.0.0.0:80 name bind_1
   bind :::80 v4v6 name bind_2
   http-request set-var(txn.Base) base
+  http-request set-var(txn.Host) req.hdr(Host)
   mode http
   default_backend default_backend
 


### PR DESCRIPTION
ACL of response-set-header (req.Hdr(Host)) cannot be matched because it
is incompatible with http-response context. The applied fix is to
capture the Host header in a variable at the request context and use the
variable later for any http-response rules.