### PR TITLE
MINOR: remove deprecated "http-use-htx" from stats section

### DIFF
--- a/fs/etc/haproxy/haproxy.cfg
+++ b/fs/etc/haproxy/haproxy.cfg
@@ -63,7 +63,6 @@ frontend healthz
 frontend stats
    mode http
    bind *:1024
-   option http-use-htx
    http-request use-service prometheus-exporter if { path /metrics }
    stats enable
    stats uri /


### PR DESCRIPTION
Closes #205.

Since HTX is the defacto mode, we can drop this option.