### PR TITLE
remove doubles from rbac role

### DIFF
--- a/deploy/haproxy-ingress-daemonset.yaml
+++ b/deploy/haproxy-ingress-daemonset.yaml
@@ -52,14 +52,6 @@ rules:
   - create
   - patch
   - update
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - get
-  - list
-  - watch
 
 ---
 kind: ClusterRoleBinding

--- a/deploy/haproxy-ingress.yaml
+++ b/deploy/haproxy-ingress.yaml
@@ -52,14 +52,6 @@ rules:
   - create
   - patch
   - update
-- apiGroups:
-  - extensions
-  resources:
-  - ingresses
-  verbs:
-  - get
-  - list
-  - watch
 
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
Apparently, a double declaration of the extensions API-group made it into both the daemonset as well as the deployment example.

I have taken the liberty to suggest the removal of the latter.

In any case, thank you very much for developing the haproxy ingress-controller and making your efforts available to the public. Cheers!