### PR TITLE
Making Kubernetes Shared Informer resync period configurable via CLI

### DIFF
--- a/controller/kubernetes.go
+++ b/controller/kubernetes.go
@@ -101,7 +101,7 @@ func (k *K8s) EventsNamespaces(channel chan *Namespace, stop chan struct{}) {
 	_, controller := cache.NewInformer( // also take a look at NewSharedIndexInformer
 		watchlist,
 		&corev1.Namespace{},
-		1*time.Second, //Duration is int64
+		10*time.Minute, //Duration is int64
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				data := obj.(*corev1.Namespace)
@@ -168,7 +168,7 @@ func (k *K8s) EventsEndpoints(channel chan *Endpoints, stop chan struct{}) {
 	_, controller := cache.NewInformer( // also take a look at NewSharedIndexInformer
 		watchlist,
 		&corev1.Endpoints{},
-		1*time.Second, //Duration is int64
+		10*time.Minute, //Duration is int64
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				item, err := k.convertToEndpoints(obj, ADDED)
@@ -264,7 +264,7 @@ func (k *K8s) EventsIngresses(channel chan *Ingress, stop chan struct{}) {
 	_, controller := cache.NewInformer( // also take a look at NewSharedIndexInformer
 		watchlist,
 		&extensions.Ingress{},
-		1*time.Second, //Duration is int64
+		10*time.Minute, //Duration is int64
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				data := obj.(*extensions.Ingress)
@@ -343,7 +343,7 @@ func (k *K8s) EventsServices(channel chan *Service, stop chan struct{}, publishS
 	_, controller := cache.NewInformer( // also take a look at NewSharedIndexInformer
 		watchlist,
 		&corev1.Service{},
-		1*time.Second, //Duration is int64
+		10*time.Minute, //Duration is int64
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				data := obj.(*corev1.Service)
@@ -457,7 +457,7 @@ func (k *K8s) EventsConfigfMaps(channel chan *ConfigMap, stop chan struct{}) {
 	_, controller := cache.NewInformer( // also take a look at NewSharedIndexInformer
 		watchlist,
 		&corev1.ConfigMap{},
-		1*time.Second, //Duration is int64
+		10*time.Minute, //Duration is int64
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				data := obj.(*corev1.ConfigMap)
@@ -524,7 +524,7 @@ func (k *K8s) EventsSecrets(channel chan *Secret, stop chan struct{}) {
 	_, controller := cache.NewInformer( // also take a look at NewSharedIndexInformer
 		watchlist,
 		&corev1.Secret{},
-		1*time.Second, //Duration is int64
+		10*time.Minute, //Duration is int64
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				data := obj.(*corev1.Secret)

--- a/controller/utils/flags.go
+++ b/controller/utils/flags.go
@@ -74,5 +74,6 @@ type OSArgs struct {
 	IngressClass          string         `long:"ingress.class" default:"" description:"ingress.class to monitor in multiple controllers environment"`
 	PublishService        string         `long:"publish-service" default:"" description:"Takes the form namespace/name. The controller mirrors the address of this service's endpoints to the load-balancer status of all Ingress objects it satisfies"`
 	SyncPeriod            time.Duration  `long:"sync-period" default:"5s" description:"Sets the synchronization period at which the controller executes the configuration sync"`
+	ResyncPeriod          time.Duration  `long:"cache-resync-period" default:"1m" description:"Sets the underlying Shared Informer resync period: higher values will lower down pressure on the GC and subsequently to CPU"`
 	LogLevel              LogLevelValue  `long:"log" default:"info" description:"level of log messages you can see"`
 }

--- a/documentation/controller.md
+++ b/documentation/controller.md
@@ -52,6 +52,12 @@ you can run image with arguments:
   - optional, must be in format `namespace/name`
   - The controller mirrors the address of the service's endpoints to the load-balancer status of all Ingress objects it satisfies.
 
+- `--cache-resync-period`
+  - optional (must adhere to [`time.Duration`](https://golang.org/pkg/time/#ParseDuration) format),
+    sets the default re-synchronization period at which the controller will re-apply the desired state
+  - fine tuning parameter useful for large scale deployments, as reported in the [issue #216](https://github.com/haproxytech/kubernetes-ingress/issues/216)
+  - default value to `10m` (_10 minutes_)
+
 - `--sync-period`
   - optional (must adhere to [`time.Duration`](https://golang.org/pkg/time/#ParseDuration) format),
     sets the synchronization period at which the controller executes the configuration sync

--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ func main() {
 	c.SetDefaultAnnotation("default-backend-service", defaultBackendSvc)
 	c.SetDefaultAnnotation("ssl-certificate", defaultCertificate)
 	c.SetDefaultAnnotation("sync-period", osArgs.SyncPeriod.String())
+	c.SetDefaultAnnotation("cache-resync-period", osArgs.ResyncPeriod.String())
 
 	if len(osArgs.Version) > 0 {
 		fmt.Printf("HAProxy Ingress Controller %s %s%s\n\n", GitTag, GitCommit, GitDirty)
@@ -88,6 +89,7 @@ func main() {
 	logger.Printf("Default backend service: %s", defaultBackendSvc)
 	logger.Printf("Default ssl certificate: %s", defaultCertificate)
 	logger.Printf("Controller sync period: %s", osArgs.SyncPeriod.String())
+	logger.Printf("Kubernetes Shared Informer default resync period: %s", osArgs.ResyncPeriod.String())
 
 	if osArgs.ConfigMapTCPServices.Name != "" {
 		logger.Printf("TCP Services defined in %s/%s", osArgs.ConfigMapTCPServices.Namespace, osArgs.ConfigMapTCPServices.Name)


### PR DESCRIPTION
Closes #216.

Providing the new flag/annotation `--shared-informer-resync-period` with the default value set to 1 minute to make it backward compatible.

Documentation updated, tested locally on my _Kubernetes in Docker_ instance: please, review.