### PR TITLE
MINOR: events: race conditions fix due to Helm posthooks

### DIFF
--- a/controller/monitor.go
+++ b/controller/monitor.go
@@ -17,10 +17,11 @@ package controller
 import (
 	"time"
 
-	"github.com/haproxytech/kubernetes-ingress/controller/store"
-	"github.com/haproxytech/kubernetes-ingress/controller/utils"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
+
+	"github.com/haproxytech/kubernetes-ingress/controller/store"
+	"github.com/haproxytech/kubernetes-ingress/controller/utils"
 )
 
 func (c *HAProxyController) timeFromAnnotation(name string) (duration time.Duration) {

--- a/controller/store/events.go
+++ b/controller/store/events.go
@@ -160,6 +160,9 @@ func (k K8s) EventIngress(ns *Namespace, data *Ingress, controllerClass string) 
 			return false
 		}
 		if old, ok := ns.Ingresses[data.Name]; ok {
+			if old.Status == DELETED {
+				ns.Ingresses[data.Name].Status = ADDED
+			}
 			data.Status = old.Status
 			if !old.Equal(data) {
 				data.Status = MODIFIED
@@ -225,6 +228,9 @@ func (k K8s) EventEndpoints(ns *Namespace, data *Endpoints, processEndpointsSrvs
 		return true
 	case ADDED:
 		if old, ok := ns.Endpoints[data.Service.Value]; ok {
+			if old.Status == DELETED {
+				ns.Endpoints[data.Service.Value].Status = ADDED
+			}
 			if !old.Equal(data) {
 				data.Status = MODIFIED
 				return k.EventEndpoints(ns, data, processEndpointsSrvs)
@@ -262,6 +268,9 @@ func (k K8s) EventService(ns *Namespace, data *Service) (updateRequired bool) {
 		updateRequired = true
 	case ADDED:
 		if old, ok := ns.Services[data.Name]; ok {
+			if old.Status == DELETED {
+				ns.Services[data.Name].Status = ADDED
+			}
 			if !old.Equal(data) {
 				data.Status = MODIFIED
 				return k.EventService(ns, data)
@@ -336,6 +345,9 @@ func (k K8s) EventSecret(ns *Namespace, data *Secret) (updateRequired bool) {
 		updateRequired = true
 	case ADDED:
 		if old, ok := ns.Secret[data.Name]; ok {
+			if old.Status == DELETED {
+				ns.Secret[data.Name].Status = ADDED
+			}
 			if !old.Equal(data) {
 				data.Status = MODIFIED
 				return k.EventSecret(ns, data)


### PR DESCRIPTION
Fixes #235.

More context on the issue is needed: due to a Helm hook (`hook-delete-policy`) a _Service_ object is going to be deleted and created back when a new hook is launched ([docs](https://helm.sh/docs/topics/charts_hooks/#hook-deletion-policies)).

According to the internal store, when a Kubernetes resource is deleted, the controller is going to set its status to `DELETED`.

https://github.com/haproxytech/kubernetes-ingress/blob/08ec18ea7673c0012fb636f123e61b6084d6bd91/controller/store/events.go#L273-L282

This _marking_ is needed when dealing with the current vs. desired state of the HAProxy configuration file, allowing to deleted or not specific frontend, backend, or other resources.

Once the _reconciliation_ (sic) is completed, the Controller performs [a sort of GC of the store](https://github.com/haproxytech/kubernetes-ingress/blob/08ec18ea7673c0012fb636f123e61b6084d6bd91/controller/store/store.go#L47-L126).

https://github.com/haproxytech/kubernetes-ingress/blob/08ec18ea7673c0012fb636f123e61b6084d6bd91/controller/controller.go#L226

https://github.com/haproxytech/kubernetes-ingress/blob/08ec18ea7673c0012fb636f123e61b6084d6bd91/controller/controller.go#L381-L387

What happens is that the _Service_, although recreated, has been marked `DELETED` and is going to be removed from the local store, causing a failure on the Ingress update since it cannot be retrieved anymore.

With this PR we're going to force the `Status` of each resource to `ADDED` since the Store models `Equal` function doesn't (and there's no need to) check if the `Status` has been edited or not.