### PR TITLE
CI: supporting networking.k8s.io Ingress API group

### DIFF
--- a/controller/kubernetes.go
+++ b/controller/kubernetes.go
@@ -695,8 +695,9 @@ func (k *K8s) IsMatchingSelectedIngressClass(name string) error {
 	}
 	if k.IsNetworkingV1Beta1ApiSupported() {
 		ic, err := k.API.NetworkingV1beta1().IngressClasses().Get(context.Background(), name, metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("the requested IngressClass %s doesn't exist", name)
+		if err != nil && k8serror.IsNotFound(err) {
+			k.Logger.Warningf("the requested IngressClass %s doesn't exist, for upcoming releases this will be mandatory", name)
+			return nil
 		}
 		controllerName = ic.Spec.Controller
 	}

--- a/controller/store/convert.go
+++ b/controller/store/convert.go
@@ -52,6 +52,10 @@ func getIngressClass(annotations map[string]string, specValue *string) string {
 	if v, ok := annotations["kubernetes.io/ingress.class"]; ok {
 		return v
 	}
+	// HAProxy Tech Ingress Controller allows also non prefixed annotations
+	if v, ok := annotations["ingress.class"]; ok {
+		return v
+	}
 	if specValue != nil {
 		return *specValue
 	}

--- a/controller/store/convert.go
+++ b/controller/store/convert.go
@@ -46,28 +46,11 @@ type ingressNetworkingV1Beta1Strategy struct {
 	obj *networkingv1beta1.Ingress
 }
 
-func getIngressClass(annotations map[string]string, specValue *string) string {
-	// Giving priority to annotation due to backward compatibility as suggested
-	// by Kuberentes documentation.
-	if v, ok := annotations["kubernetes.io/ingress.class"]; ok {
-		return v
-	}
-	// HAProxy Tech Ingress Controller allows also non prefixed annotations
-	if v, ok := annotations["ingress.class"]; ok {
-		return v
-	}
-	if specValue != nil {
-		return *specValue
-	}
-	return ""
-}
-
 func (n ingressNetworkingV1Beta1Strategy) Convert() *Ingress {
 	return &Ingress{
 		APIVersion:  "networking.k8s.io/v1beta1",
 		Namespace:   n.obj.GetNamespace(),
 		Name:        n.obj.GetName(),
-		Class:       getIngressClass(n.obj.GetAnnotations(), n.obj.Spec.IngressClassName),
 		Annotations: ConvertToMapStringW(n.obj.GetAnnotations()),
 		Rules: func(ingressRules []networkingv1beta1.IngressRule) map[string]*IngressRule {
 			rules := make(map[string]*IngressRule)
@@ -149,7 +132,6 @@ func (e ingressExtensionsStrategy) Convert() *Ingress {
 		APIVersion:  "extensions/v1beta1",
 		Namespace:   e.obj.GetNamespace(),
 		Name:        e.obj.GetName(),
-		Class:       getIngressClass(e.obj.GetAnnotations(), e.obj.Spec.IngressClassName),
 		Annotations: ConvertToMapStringW(e.obj.GetAnnotations()),
 		Rules: func(ingressRules []extensionsv1beta1.IngressRule) map[string]*IngressRule {
 			rules := make(map[string]*IngressRule)
@@ -231,7 +213,6 @@ func (n ingressNetworkingV1Strategy) Convert() *Ingress {
 		APIVersion:  "networking.k8s.io/v1",
 		Namespace:   n.obj.GetNamespace(),
 		Name:        n.obj.GetName(),
-		Class:       getIngressClass(n.obj.GetAnnotations(), n.obj.Spec.IngressClassName),
 		Annotations: ConvertToMapStringW(n.obj.GetAnnotations()),
 		Rules: func(ingressRules []networkingv1.IngressRule) map[string]*IngressRule {
 			rules := make(map[string]*IngressRule)

--- a/controller/store/events.go
+++ b/controller/store/events.go
@@ -36,7 +36,10 @@ func (k K8s) EventNamespace(ns *Namespace, data *Namespace) (updateRequired bool
 }
 
 func (k K8s) EventIngress(ns *Namespace, data *Ingress, controllerClass string) (updateRequired bool) {
-	ingressClass := data.Class
+	var ingressClass string
+	ic, _ := k.GetValueFromAnnotations("ingress.class", data.Annotations)
+	ingressClass = ic.Value
+
 	updateRequired = false
 	switch data.Status {
 	case MODIFIED:

--- a/controller/store/types-equal.go
+++ b/controller/store/types-equal.go
@@ -86,9 +86,6 @@ func (a *Ingress) Equal(b *Ingress) bool {
 	if a.Name != b.Name {
 		return false
 	}
-	if a.Class != b.Class {
-		return false
-	}
 	if len(a.Rules) != len(b.Rules) {
 		return false
 	}

--- a/controller/store/types.go
+++ b/controller/store/types.go
@@ -90,7 +90,6 @@ type Ingress struct {
 	APIVersion     string
 	Namespace      string
 	Name           string
-	Class          string
 	Annotations    MapStringW
 	Rules          map[string]*IngressRule
 	DefaultBackend *IngressPath

--- a/deploy/kind/config/3.rbac.yaml
+++ b/deploy/kind/config/3.rbac.yaml
@@ -29,16 +29,14 @@ rules:
      - patch
      - update
  - apiGroups:
-   - "extensions"
+     - "networking.k8s.io"
    resources:
-     - ingresses
-     - ingresses/status
+     - ingressclasses
    verbs:
      - get
-     - list
-     - watch
  - apiGroups:
-   - "networking.k8s.io/v1beta1"
+   - "extensions"
+   - "networking.k8s.io"
    resources:
      - ingresses
      - ingresses/status
@@ -46,7 +44,6 @@ rules:
      - get
      - list
      - watch
-     - update
  - apiGroups:
    - ""
    resources:


### PR DESCRIPTION
This PR should fix the CI, ignoring the missing `IngressClass` resource on clusters running version < 1.19.