### PR TITLE
Upgrading KinD GitHub Action due to deprecation path

### DIFF
--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '^1.15.1' # The Go version to download (if necessary) and use.
-    - uses: engineerd/setup-kind@v0.4.0
+    - uses: engineerd/setup-kind@v0.5.0
       with:
           name: dev
           config: deploy/kind/kind-config.yaml

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,7 @@ jobs:
         with:
           fetch-depth: 10
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2.2.0
+        uses: golangci/golangci-lint-action@v2.3.0
         with:
           version: v1.28
           args: --timeout 2m


### PR DESCRIPTION
The KinD GH Action is using the `core.addpath` method that [has been deprecated](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/).

Using the [0.5.0 release](https://github.com/engineerd/setup-kind/releases/tag/v0.5.0) should prevent future issues.