### PR TITLE
Remove lowercasing on paths

### DIFF
--- a/controller/requests.go
+++ b/controller/requests.go
@@ -154,7 +154,7 @@ func (c *HAProxyController) FrontendHTTPReqsRefresh() (reload bool) {
 			Type:     "set-var",
 			VarName:  "path",
 			VarScope: "txn",
-			VarExpr:  "path,lower",
+			VarExpr:  "path",
 		}
 		c.Logger.Error(c.Client.FrontendHTTPRequestRuleCreate(frontend, setVarRule))
 		// STATIC: SET_VARIABLE txn.host (to use in http rules)

--- a/fs/etc/haproxy/haproxy.cfg
+++ b/fs/etc/haproxy/haproxy.cfg
@@ -40,7 +40,7 @@ frontend https
   bind 0.0.0.0:443 name bind_1
   bind :::443 v4v6 name bind_2
   http-request set-var(txn.host) req.hdr(Host),field(1,:),lower
-  http-request set-var(txn.path) path,lower
+  http-request set-var(txn.path) path
   http-request set-var(txn.base) base
   http-request set-header X-Forwarded-Proto https if { ssl_fc }
   default_backend default_backend
@@ -49,7 +49,7 @@ frontend http
   bind 0.0.0.0:80 name bind_1
   bind :::80 v4v6 name bind_2
   http-request set-var(txn.host) req.hdr(Host),field(1,:),lower
-  http-request set-var(txn.path) path,lower
+  http-request set-var(txn.path) path
   http-request set-var(txn.base) base
   mode http
   default_backend default_backend


### PR DESCRIPTION
The path expressions are case sensitive and fail to match where the ingress has uppercase characters in the request paths. This leaves the path unchanged allowing a correctly cased ingress path to match.

Fixes #251 