### PR TITLE
Remove lowercasing on path

### DIFF
--- a/controller/configuration.go
+++ b/controller/configuration.go
@@ -66,7 +66,7 @@ func (c *Configuration) HAProxyRulesInit() error {
 		c.HAProxyRules.AddRule(rules.ReqSetVar{
 			Name:       "path",
 			Scope:      "txn",
-			Expression: "path,lower",
+			Expression: "path",
 		}, FrontendHTTP, FrontendHTTPS),
 	)
 	c.MapFiles.AppendRow(0, "# Ingress SNIs")


### PR DESCRIPTION
I thought I would give master a go to see if it was affected by this issue. I confirmed that certs fail to issue without this change.

The path expressions are case sensitive and fail to match where the ingress has uppercase characters in the request paths. This leaves the path unchanged allowing a correctly cased ingress path to match.

Fixes #251 (on master)