### PR TITLE
Prevent aligning of backends for externalName services

### DIFF
--- a/controller/ingress/endpoints.go
+++ b/controller/ingress/endpoints.go
@@ -91,7 +91,9 @@ func (route *Route) handleEndpoints() {
 		return
 	}
 	route.endpoints.BackendName = route.BackendName
-	route.alignHAProxySrvs()
+	if route.service.DNS == "" {
+		route.alignHAProxySrvs()
+	}
 	activeAnnotations := route.getServerAnnotations()
 	for srvName, srv := range route.endpoints.HAProxySrvs {
 		if srv.Modified || route.NewBackend || activeAnnotations {


### PR DESCRIPTION
`externalName` services are handled separately and has a single server generated. The `v1.4` branch had this check that appears to have been removed during various refactors. I have tested a custom image with this scenerio and the issue in #261 is no longer present.

In addition to the superfluous reloads, the `externalName` service had an ever growing list of servers appended to the configuration on every reload. This is no longer happening.