### PR TITLE
DOC/MEDIUM: Documentation formatting

### DIFF
--- a/documentation/doc.yaml
+++ b/documentation/doc.yaml
@@ -11,22 +11,24 @@ image_arguments:
         - --configmap=default/my-configmap
   - argument: --configmap-tcp-services
     tip:
-      - Ports of TCP services should be exposed on the controller's kubernetes service
+      - Ports of TCP services should be exposed on the controller's Kubernetes service
     description: |- 
       Sets the ConfigMap that contains mappings for TCP services to proxy through the ingress controller. This ConfigMap contains mappings like this:
-        <pre>apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: tcp
-          namespace: default
-        data:
-          3306:              # Port where the frontend is going to listen to.
-            tcp/mysql:3306   # Kubernetes service to use for the backend.
-          389:
-            tcp/ldap:389:ssl # ssl option will enable ssl offloading for target service.
-          6379:
-            tcp/redis:6379
-        </pre>
+      
+      ```yaml
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: tcp
+        namespace: default
+      data:
+        3306:              # Port where the frontend is going to listen to.
+          tcp/mysql:3306   # Kubernetes service to use for the backend.
+        389:
+          tcp/ldap:389:ssl # ssl option will enable ssl offloading for target service.
+        6379:
+          tcp/redis:6379
+      ```
     values:
       - The name of the ConfigMap that contains mappings for TCP services
     version_min: "1.4"
@@ -35,25 +37,27 @@ image_arguments:
         - --configmap-tcp-services=default/my-tcpservices-configmap
   - argument: --configmap-errorfile
     description: |-
-      Sets the ConfigMap object that defines contents to serve instead of HAProxy errors.</br>
-      As explained in the [haproxy documentation](https://cbonte.github.io/haproxy-dconv/2.0/configuration.html#4.2-errorfile) it is important to understand that errorfile content is not meant to rewrite errors returned by the server, but rather errors detected and returned by HAProxy.</br>
-      In the following example, instead of HAProxy returning 503 error it will return the coressponding content in the configmap:
-        <pre>apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: errorfile
-          namespace: default
-        data:
-          503: |-
-            HTTP/1.0 503 Service Unavailable
-            Cache-Control: no-cache
-            Connection: close
-            Content-Type: text/html
-        
-            &lt;html\&gt;&lt;body\&gt;&lt;h1\&gt;Oops, that's embarassing!&lt/h1&gt
-            There are no servers available to handle your request.
-            &lt/body&gt&lt/html&gt
-         </pre>
+      Sets the ConfigMap object that defines contents to serve instead of HAProxy errors.
+      As explained in the [haproxy documentation](https://cbonte.github.io/haproxy-dconv/2.0/configuration.html#4.2-errorfile) it is important to understand that errorfile content is not meant to rewrite errors returned by the server, but rather errors detected and returned by HAProxy.
+      In the following example, instead of HAProxy returning a 503 error, it will return the coressponding content in the ConfigMap:
+
+      ```yaml
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: errorfile
+        namespace: default
+      data:
+        503: |-
+          HTTP/1.0 503 Service Unavailable
+          Cache-Control: no-cache
+          Connection: close
+          Content-Type: text/html
+      
+          &lt;html\&gt;&lt;body\&gt;&lt;h1\&gt;Oops, that's embarassing!&lt/h1&gt
+          There are no servers available to handle your request.
+          &lt/body&gt&lt/html&gt
+      ```
     values: 
       - The name of the ConfigMap containing errorfile content
     version_min: "1.5"
@@ -256,14 +260,14 @@ image_arguments:
 groups:
   config-snippet:
     header: |-
-      - Insert raw HAProxy configuration in specific HAProxy config sections.</br>
+      - Insert raw HAProxy configuration in specific HAProxy config sections.
       - There is **no data validation** done by Ingress Controller. If input is incorret, HAProxy will fail the reload.
   cookie-persistence:
     header: |-
       - Configure sticky session via cookie-based persistence.
     footer: |-
       Configuring the cookie can be done in two different ways: 
-      - Using `cookie-persistence` annotation.</br>
+      - Using `cookie-persistence` annotation.
         However, currently, this **does not work** when deploying more than one ingress controller pod. For such case (multiple IC pods) the following `dynamic` cookie configuration via `backend-config-snippet` annotation an be used.
       - Using [`backend-config-snippet`](#config-snippet) annotation for more cookie options.
         
@@ -304,7 +308,7 @@ annotations:
     dependencies: ""
     default: ""
     description:
-      - Enable the selected authentication strategy, currently only *basic-auth* value is supported.
+      - Enables the selected authentication strategy.
     tip: []
     values:
       - basic-auth
@@ -312,39 +316,44 @@ annotations:
       - configmap
       - ingress
     version_min: "1.5"
-    example: ['auth-type: basic-auth']
+    example:
+      - 'auth-type: basic-auth'
+      - 'auth-secret: default/haproxy-credentials'
   - title: auth-secret
     type: string
     group: authentication
     dependencies: auth-type
     default: ""
     description:
-      - Select the Kubernetes Secret where authentication data can be found.</br>
-      - The annotaiton format is a secret path '*namespace/secretName*', if the namespace is ommited (path is only '*secretName*') then the ingress namespace will be used.</br>
-      - |-
-        For Basic Authentication the Secret data should contain user credentials in the form of '*username: encrypted and base-64 encoded passowrd*'.
-
-        Example:
-        > bob: JDEkYWJjJEJYQnFwYjlCWmNaaFhMZ2JlZS4wcy8=
-
+      - Selects the Kubernetes Secret where authentication data can be found.
     tip:
       - Encrypted passwords are evaluated using the crypt(3) function, so depending on the system's capabilities, different algorithms are supported.
       - Unencrypted passwords (used with HAProxy [insecure-password](https://cbonte.github.io/haproxy-dconv/2.0/configuration.html#3.4-user) ) **are not accepted**.
-    values:
-      - |-
-        Any Kubernetes generic Secret resource that can be created in the following way,
+    values: |-
+      The annotaiton format is a secret path '*namespace/secretName*'. If the namespace is ommited (path is only '*secretName*') then the ingress namespace will be used. 
+      For Basic Authentication, the Secret data should contain user credentials in the form of `username: encrypted and base-64 encoded passowrd`.
+      For example: 
+      
+      ```
+      bob: JDEkYWJjJEJYQnFwYjlCWmNaaFhMZ2JlZS4wcy8=
+      ```
+      
+      Create the Kubernetes Secret resource in the following way:
 
-          ```bash
-          kubectl create secret generic haproxy-credentials \
-            --from-literal=bob=$(openssl passwd -1 bobPassword) \
-            --from-literal=alice=$(openssl passwd -1 alicePassword) \
-          # secret/haproxy-credentials created
-          ```
+      ```bash
+      kubectl create secret generic haproxy-credentials \
+        --from-literal=bob=$(openssl passwd -1 bobPassword) \
+        --from-literal=alice=$(openssl passwd -1 alicePassword)
+        
+        # secret/haproxy-credentials created
+      ```
     applies_to:
       - configmap
       - ingress
     version_min: "1.5"
-    example: ['auth-secret: default/haproxy-credentials']
+    example:
+      - 'auth-type: basic-auth'
+      - 'auth-secret: default/haproxy-credentials'
   - title: blacklist
     type: IPs or CIDRs
     group: access-control
@@ -748,10 +757,10 @@ annotations:
     dependencies: ""
     default: 403
     description:
-      - Sets the status code to return upon rate limiting has been triggered.
+      - Sets the status code to return when rate limiting has been triggered.
     tip: []
     values:
-      - HTTP status codes; Defaults to 403
+      - HTTP status codes; Defaults to 403.
     applies_to:
       - configmap
       - ingress
@@ -763,11 +772,10 @@ annotations:
     dependencies: ""
     default: ""
     description:
-    - Sets the maximum number of requests that will be accepted from a source IP address
-      during the `rate-limit-period`.
-    - To track the http requests rate, a stick-table named "Ratelimit-<period-in-ms>" will be created. Example, If the rate-limit-period is set to 2s the name of the table will be "Ratelimit-2000".
+    - Sets the maximum number of requests that will be accepted from a source IP address during the `rate-limit-period`.
     tip:
-    - If this number is exceeded, HAProxy will deny requests with 403 status code
+    - If this number is exceeded, HAProxy will deny requests with 403 status code.
+    - To track the http requests rate, a stick-table named "Ratelimit-<period-in-ms>" will be created. For example, if the `rate-limit-period` is set to *2s*, the name of the table will be *Ratelimit-2000*.
     values:
     - An integer representing the maximum number of requests to accept
     applies_to:
@@ -893,7 +901,7 @@ annotations:
     description:
     - Enables HTTP request redirection based on host and port substitution in original request.
     tip:
-    - HTTP redirection code is settable with request-redirect-code annotation.
+    - HTTP redirection code is settable with `request-redirect-code` annotation.
     - Port alone is not allowed.
     values:
     - host
@@ -971,9 +979,9 @@ annotations:
     dependencies: ""
     default: ""
     description:
-    - value is the path of a secret containing a CA certificate (certificate authority)
-      enabling HAProxy to verify backends certificate via *ca-file* directive.
-      When CA certificate is properly configured this will also sets *verify*
+    - Specifies the path of a secret containing a CA certificate (certificate authority)
+      enabling HAProxy to verify a backend's certificate via the `ca-file` directive.
+      When the CA certificate is properly configured this also sets the HAProxy *verify*
       directive to *required*.
     tip:
       - The secret must use 'tls.crt' key.
@@ -991,9 +999,7 @@ annotations:
     dependencies: ""
     default: ""
     description:
-    - value is the path of a secret containing a client
-      certificate that haproxy can provide during a SSL communication with
-      backend servers via *crt* directive. 
+    - Specifies the path of a secret containing a client certificate that HAProxy can provide during SSL communication with the backend servers via the HAProxy `crt` directive. 
     tip:
        - The secret must use 'tls.key' and 'tls.crt' keys.
     values:
@@ -1011,11 +1017,11 @@ annotations:
     default: ""
     description:
     - HTTP/1.1 is the default protocol for backend servers communication.
-      Currently server-proto annotation supports only "h2" value (supporting
-      fcgi is also planned) which forces the HTTP/2 on clear for backend
+      Currently, the `server-proto` annotation supports only "h2" as a value (supporting
+      fcgi is also planned) which transmits HTTP/2 messages in the clear to the backend
       servers.
-    - When SSL is enabled on the backend, server-proto is ignored and both
-      http/1.1 and http/2 are advertised via ALPN.
+    - However, when SSL is enabled on the backend, `server-proto` is ignored and both
+      HTTP/1.1 and HTTP/2 are advertised via ALPN and transmitted as encrypted messages.
     tip: []
     values:
     - "h2"
@@ -1067,12 +1073,12 @@ annotations:
     description:
     - Sets the number of server slots to provision in order for HAProxy to scale 
       dynamically with no reload.
-      If this number is greater than available endpoints/addresses, the remaining 
-      slots will be disabled (put on stand by) and ready to be used.
-      if this number is lower, the remaining endpoints/addresses will be added after
-      scaling HAProxy backend with a reload.
+      If this number is greater than the available endpoints/addresses, the remaining 
+      slots will be disabled (put on stand-by) and ready to be used.
+      If this number is lower, the remaining endpoints/addresses will be added after
+      scaling the HAProxy backend with a reload.
     tip:
-      - Equivalent old annotations are "servers-increment" and "server-slots"
+      - Equivalent old annotations are `servers-increment` and `server-slots`
     values:
     - Integer value indicating the number of backend servers to provision. Defaults to 42.
     applies_to:
@@ -1161,9 +1167,9 @@ annotations:
     dependencies: tls-secret
     default: "443"
     description:
-    - Sets the HTTPS port in redirection URL in case of HTTP to HTTPS traffic redirection.
+    - Sets the HTTPS port to redirect to when HTTP to HTTPS traffic redirection is enabled  when `ssl-redirect` is true.
     tip:
-    - When setting the HTTPS port value, keep in mind this is the HTTPS port as seen by the client, not as set on the Ingress Controller. The reason of this distinction lies in the fact there will probably be some middleware with its own ports mapping between the client and the Ingress Controller. As a consequence, it must be set with a distinct consideration of how the HTTPS port is set on Ingress Controller with the https-bind-port command line option. 
+    - When setting the HTTPS port value, keep in mind that this is the HTTPS port as seen by the client, not as set on the Ingress Controller. The reason for this distinction lies in the fact that there will probably be some middleware with its own ports mapping between the client and the Ingress Controller. As a consequence, it must be set with a distinct consideration of how the HTTPS port is set on Ingress Controller with the `https-bind-port` command line option. 
     values:
     - Integer HTTPS port number
     applies_to:


### PR DESCRIPTION
- Replaced `<pre>` tags with Markdown code blocks. Put code keyword backticks around some keywords. 
- Improved grammar in a few descriptions. 
- Changed the `auth-secret` definition so that the description of the values is under the values key instead of the description key. This makes the table where we show the description only more succinct. 
- For `auth-type` and `auth-secret`, the example now shows both of these keys together because they are dependant upon one another.