### PR TITLE
BUG/MINOR: healthz: listen on IPv6 too

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -270,9 +270,21 @@ func (c *HAProxyController) updateHAProxy() {
 			return c.Client.FrontendBindEdit("healthz",
 				models.Bind{
 					Name:    "v4",
-					Address: "*:1042",
+					Address: "0.0.0.0:1042",
 				})
 		}))
+
+		if !c.osArgs.DisableIPV6 {
+			logger.Panic(c.clientAPIClosure(func() error {
+				return c.Client.FrontendBindCreate("healthz",
+					models.Bind{
+						Name:    "v6",
+						Address: ":::1042",
+						V4v6:    true,
+					})
+			}))
+		}
+
 		logger.Debugf("healthz frontend exposed for readiness probe")
 		c.ready = true
 	}


### PR DESCRIPTION
Hi,

There was a bug in the `healthz` frontend that made it listen on IPv4 only
(i.e. `*:1042`, which is implicitly `0.0.0.0:1042`).

This made the liveliness probe fail on v6 only clusters as the endpoint
was not listening on IPv6:
```
frontend healthz
  mode http
  bind *:1042 name v4
  monitor-uri /healthz
  option dontlog-normal
```
which translates into the following socket:
```
tcp        0      0 0.0.0.0:1042            0.0.0.0:*               LISTEN
```

This commits adds another IPv6 bind on the frontend only if the
`--disable-ipv6` param is not set:

```
frontend healthz
  mode http
  bind 0.0.0.0:1042 name v4
  bind :::1042 name v6 v4v6
  monitor-uri /healthz
  option dontlog-normal
```
which translates to:
```
tcp        0      0 0.0.0.0:1042            0.0.0.0:*               LISTEN
tcp        0      0 :::1042                 :::*                    LISTEN
```


Cheers !