### PR TITLE
BUG/MEDIUM: stats frontend: listen IPv6 too

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -413,6 +413,14 @@ func (c *HAProxyController) handleBinds() (err error) {
 	}
 	if !c.osArgs.DisableIPV6 {
 		protos["v6"] = c.osArgs.IPV6BindAddr
+
+		// IPv6 not disabled, so add v6 listening to stats frontend
+		errors.Add(c.Client.FrontendBindCreate("stats",
+			models.Bind{
+				Name:    "v6",
+				Address: ":::1024",
+				V4v6:    false,
+			}))
 	}
 	for ftName, ftPort := range frontends {
 		for proto, addr := range protos {


### PR DESCRIPTION
Hi,
I'm not really sure about this MR..
 It adds dual-stack to the stats fronted. However, as-is, it won't obbey to --disable-ipv6 args (who would ever use those anyways ? :P)

Without binding on v6, the stats frontend doesn't work on v6-only clusters,

Let me know what you think.

Cheers !