### PR TITLE
Feature expose annotated NodePorts

### DIFF
--- a/controller/kubernetes.go
+++ b/controller/kubernetes.go
@@ -368,6 +368,7 @@ func (k *K8s) EventsServices(channel chan SyncDataEvent, stop chan struct{}, inf
 					Name:     sp.Name,
 					Protocol: string(sp.Protocol),
 					Port:     int64(sp.Port),
+					NodePort: int64(sp.NodePort),
 				})
 			}
 			if publishSvc != nil {
@@ -426,6 +427,7 @@ func (k *K8s) EventsServices(channel chan SyncDataEvent, stop chan struct{}, inf
 					Name:     sp.Name,
 					Protocol: string(sp.Protocol),
 					Port:     int64(sp.Port),
+					NodePort: int64(sp.NodePort),
 				})
 			}
 
@@ -443,6 +445,7 @@ func (k *K8s) EventsServices(channel chan SyncDataEvent, stop chan struct{}, inf
 					Name:     sp.Name,
 					Protocol: string(sp.Protocol),
 					Port:     int64(sp.Port),
+					NodePort: int64(sp.NodePort),
 				})
 			}
 			if item2.Equal(item1) {

--- a/controller/store/types.go
+++ b/controller/store/types.go
@@ -19,6 +19,7 @@ type ServicePort struct {
 	Name     string
 	Protocol string
 	Port     int64
+	NodePort int64
 	Status   Status
 }
 


### PR DESCRIPTION
Replaces the ConfigMap mechanism with examining NodePort annotations directly for deciding how to expose TCP ports.

This isn't a ready, complete pull request. Namely, it's not backwards compatible with ConfigMaps.

See #295

Sample Service:
```
  apiVersion: v1
  kind: Service
  metadata:
    name: myapp
    annotations:
      haproxy.org/expose: 'true'
      haproxy.org/ssl-offloading: 'true'
      haproxy.org/check: 'false'
      haproxy.org/send-proxy-protocol: 'proxy-v2'
      haproxy.org/whitelist: '1.2.3.4/32, 5.6.7.8/28'
  spec:
    selector:
      app: myapp
    type: NodePort
    ports:
    - name: port1
      protocol: TCP
      port: 8023
      nodePort: 30000
    - name: health
      protocol: TCP
      port: 8000
      nodePort: 30001
```

Some issues:
   - Backends don't get deleted
   - Not possible to detect when exposed port changes
   - Not possible to configure SSL individually per port

The reason I'm using NodePorts instead of LoadBalancers is that the latter are hardcoded to create ELBs on AWS (sigh). Also I'm not sure how the exposed port would be specified. (Use nodePort attribute?)