### PR TITLE
Update config on ConfigMap added event

### DIFF
--- a/controller/store/events.go
+++ b/controller/store/events.go
@@ -341,6 +341,7 @@ func (k *K8s) EventConfigMap(ns *Namespace, data *ConfigMap) (updateRequired boo
 		}
 		*cm = *data
 		cm.Loaded = true
+		updateRequired = true
 		logger.Debugf("configmap '%s/%s' processed", cm.Namespace, cm.Name)
 	case MODIFIED:
 		different := data.Annotations.SetStatus(cm.Annotations)


### PR DESCRIPTION
Currently, if the controller is started without the main ConfigMap existing, but it's added while the controller is running, the running HAProxy config isn't updated, because it's only rebuilt as a result of 'modified' or 'deleted' events, not 'added' events. 