### PR TITLE
DOC: Generalize 'backend-config-snippet' example

### DIFF
--- a/documentation/doc.yaml
+++ b/documentation/doc.yaml
@@ -771,11 +771,11 @@ annotations:
     - ingress
     - service
     version_min: "1.5"
-    example_service: |-
+    example: |-
       backend-config-snippet: |
-        http-send-name-header x-dst-server
-        stick-table type string len 32 size 100k expire 30m
-        stick on req.cook(sessionid)
+            http-send-name-header x-dst-server
+            stick-table type string len 32 size 100k expire 30m
+            stick on req.cook(sessionid)
   - title: cookie-persistence
     type: string
     group: cookie-persistence


### PR DESCRIPTION
The `backend-config-snippet` annotation should have examples for ConfigMap, Service, and Ingress. Currently, however, only the Service example is present. This commit makes the example apply to all three.

Note that I had to add space in front of the lines so that it format correctly on the rendered web page.