### PR TITLE
DOC: Generalizes the 'backend-config-snippet' example

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -594,13 +594,13 @@ Possible values:
 
 - One or more valid HAProxy directives
 
-Example (service):
+Example:
 
 ```yaml
 backend-config-snippet: |
-  http-send-name-header x-dst-server
-  stick-table type string len 32 size 100k expire 30m
-  stick on req.cook(sessionid)
+      http-send-name-header x-dst-server
+      stick-table type string len 32 size 100k expire 30m
+      stick on req.cook(sessionid)
 ```
 
 <p align='right'><a href='#available-annotations'>:arrow_up_small: back to top</a></p>

--- a/documentation/doc.yaml
+++ b/documentation/doc.yaml
@@ -771,11 +771,12 @@ annotations:
     - ingress
     - service
     version_min: "1.5"
-    example_service: |-
+    example: 
+    - |-
       backend-config-snippet: |
-        http-send-name-header x-dst-server
-        stick-table type string len 32 size 100k expire 30m
-        stick on req.cook(sessionid)
+            http-send-name-header x-dst-server
+            stick-table type string len 32 size 100k expire 30m
+            stick on req.cook(sessionid)
   - title: cookie-persistence
     type: string
     group: cookie-persistence


### PR DESCRIPTION
Makes the example for `backend-config-snippet` apply to ConfigMap, Ingress and Service. Currently, it applies only to Service.

Note: I had to add some extra whitespace in front of the lines or else it does not render with the correct spacing on haproxy.com/documentation.