### PR TITLE
BUILD: docker: Remove linux/ppc64le target

### DIFF
--- a/.github/workflows/docker_auto_release.yml
+++ b/.github/workflows/docker_auto_release.yml
@@ -7,7 +7,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     env:
-      DOCKER_PLATFORMS: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/386,linux/ppc64le
+      DOCKER_PLATFORMS: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/386
       DOCKER_IMAGE: haproxytech/kubernetes-ingress
       STABLE_BRANCH: "1.6"
     steps:

--- a/.github/workflows/docker_manual_release.yml
+++ b/.github/workflows/docker_manual_release.yml
@@ -5,7 +5,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     env:
-      DOCKER_PLATFORMS: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/386,linux/ppc64le
+      DOCKER_PLATFORMS: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/386
       DOCKER_IMAGE: haproxytech/kubernetes-ingress
       STABLE_BRANCH: "1.6"
     steps:


### PR DESCRIPTION
Remove linux/ppc64le build target, as HAProxy Alpine linux/ppc64le builds are quite wobbly and have removed as a target.