### PR TITLE
The `cookie` keyword is kept on backend after `haproxy.org/cookie-persistence` annotation is removed

### DIFF
--- a/controller/annotations/backendCookie.go
+++ b/controller/annotations/backendCookie.go
@@ -40,6 +40,7 @@ func (a *BackendCookie) Parse(input store.StringW, forceParse bool) error {
 func (a *BackendCookie) Update() error {
 	if a.cookieName == "" {
 		a.backend.Cookie = nil
+		return nil
 	}
 	cookie := models.Cookie{
 		Name:     &a.cookieName,


### PR DESCRIPTION
When using `haproxy.org/cookie-persistence`, the controller inserts in backend section the `cookie` keyword:

```text
backend com-example-polygon-http
  mode http
  balance roundrobin
  cookie SERVERID indirect nocache insert
  server SRV_1 10.42.3.168:8888 check weight 128 cookie SRV_1
  server SRV_2 10.42.4.134:8888 check weight 128 cookie SRV_2
```

But, when this annotation is removed from an existing Ingress or Service, the update process is incomplete and that directive is kept:

```text
backend com-example-polygon-http
  mode http
  balance roundrobin
  cookie indirect nocache insert # <<<<< this line was left by mistake
  server SRV_1 10.42.3.168:8888 check weight 128
  server SRV_2 10.42.4.134:8888 check weight 128
```

This PR remove the `cookie` keyword if the annotation is no longer used.