### PR TITLE
TCP services listen on IPv6 even when passing --disable-ipv6

### DIFF
--- a/controller/handler.go
+++ b/controller/handler.go
@@ -45,7 +45,9 @@ func (c *HAProxyController) initHandlers() {
 		handler.TCPServices{
 			SetDefaultService: c.setDefaultService,
 			CertDir:           c.Cfg.Env.FrontendCertDir,
+			IPv4:              !c.OSArgs.DisableIPV4,
 			AddrIPv4:          c.OSArgs.IPV4BindAddr,
+			IPv6:              !c.OSArgs.DisableIPV6,
 			AddrIPv6:          c.OSArgs.IPV6BindAddr,
 		},
 		handler.PatternFiles{},

--- a/controller/handler/tcp-services.go
+++ b/controller/handler/tcp-services.go
@@ -14,6 +14,8 @@ import (
 
 type TCPServices struct {
 	SetDefaultService func(ingress *store.Ingress, frontends []string) (reload bool, err error)
+	IPv4              bool
+	IPv6              bool
 	CertDir           string
 	AddrIPv4          string
 	AddrIPv6          string
@@ -114,15 +116,19 @@ func (t TCPServices) createTCPFrontend(api api.HAProxyClient, frontendName, bind
 	}
 	var errors utils.Errors
 	errors.Add(api.FrontendCreate(frontend))
-	errors.Add(api.FrontendBindCreate(frontendName, models.Bind{
-		Address: t.AddrIPv4 + ":" + bindPort,
-		Name:    "v4",
-	}))
-	errors.Add(api.FrontendBindCreate(frontendName, models.Bind{
-		Address: t.AddrIPv6 + ":" + bindPort,
-		Name:    "v6",
-		V4v6:    true,
-	}))
+	if t.IPv4 {
+		errors.Add(api.FrontendBindCreate(frontendName, models.Bind{
+			Address: t.AddrIPv4 + ":" + bindPort,
+			Name:    "v4",
+		}))
+	}
+	if t.IPv6 {
+		errors.Add(api.FrontendBindCreate(frontendName, models.Bind{
+			Address: t.AddrIPv6 + ":" + bindPort,
+			Name:    "v6",
+			V4v6:    true,
+		}))
+	}
 	if sslOffload {
 		errors.Add(api.FrontendEnableSSLOffload(frontend.Name, t.CertDir, false))
 	}


### PR DESCRIPTION
TCP services always bind on IPv6 and IPv4 despite of `--disable-ipv6` and `--disable-ipv4` flags.

```text
frontend tcp-14031 
  mode tcp
  bind 172.31.10.8:14031 name v4
  bind :::14031 name v6 v4v6  # !!!! this line shouldn't be here,
                              # because `--disable-ipv6` was passed to controller
  option tcplog
  default_backend com-exemplo-echo-1025
```

This PR applies to `TCPServices` the same logic used on `HTTPBind` when creating frontends.