### PR TITLE
MEDIUM: Add s6 overlay to Docker image and configure services

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -38,14 +38,30 @@ RUN mkdir -p /var/run/vars && \
 
 FROM haproxytech/haproxy-alpine:2.4
 
-COPY /fs/start.sh /
-COPY /fs/usr/local/etc/haproxy/haproxy.cfg /usr/local/etc/haproxy/
+ARG TARGETPLATFORM
+
+ARG S6_OVERLAY_VERSION=2.2.0.3
+ENV S6_OVERLAY_VERSION $S6_OVERLAY_VERSION
+
+COPY /fs /
 COPY --from=builder /src/fs/haproxy-ingress-controller .
 
-RUN apk --no-cache add socat openssl util-linux htop tzdata dumb-init && \
+RUN apk --no-cache add socat openssl util-linux htop tzdata curl && \
     rm -f /usr/local/bin/dataplaneapi /usr/bin/dataplaneapi && \
-    ln -sf /usr/bin/dumb-init /dumb-init &&\
     chgrp -R haproxy /usr/local/etc/haproxy /run /var && \
-    chmod -R g+w /usr/local/etc/haproxy /run /var
+    chmod -R g+w /usr/local/etc/haproxy /run /var && \
+    case "${TARGETPLATFORM}" in \
+        "linux/arm64")      S6_ARCH=aarch64     ;; \
+        "linux/amd64")      S6_ARCH=amd64       ;; \
+        "linux/arm/v6")     S6_ARCH=arm         ;; \
+        "linux/arm/v7")     S6_ARCH=armhf       ;; \
+        "linux/ppc64le")    S6_ARCH=ppc64le     ;; \
+        "linux/386")        S6_ARCH=x86         ;; \
+        *)                  exit 1              ;; \
+    esac && \
+    curl -sS -L -o /tmp/s6-overlay-installer "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}-installer" && \
+    chmod +x /tmp/s6-overlay-installer && \
+    /tmp/s6-overlay-installer / && \
+    rm -f /tmp/s6-overlay-installer
 
-ENTRYPOINT ["/dumb-init", "--", "/start.sh"]
+ENTRYPOINT ["/start.sh"]

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -42,6 +42,7 @@ ARG TARGETPLATFORM
 
 ARG S6_OVERLAY_VERSION=2.2.0.3
 ENV S6_OVERLAY_VERSION $S6_OVERLAY_VERSION
+ENV S6_READ_ONLY_ROOT=1
 
 COPY /fs /
 COPY --from=builder /src/fs/haproxy-ingress-controller .
@@ -49,7 +50,7 @@ COPY --from=builder /src/fs/haproxy-ingress-controller .
 RUN apk --no-cache add socat openssl util-linux htop tzdata curl && \
     rm -f /usr/local/bin/dataplaneapi /usr/bin/dataplaneapi && \
     chgrp -R haproxy /usr/local/etc/haproxy /run /var && \
-    chmod -R g+w /usr/local/etc/haproxy /run /var && \
+    chmod -R ug+rwx /usr/local/etc/haproxy /run /var && \
     case "${TARGETPLATFORM}" in \
         "linux/arm64")      S6_ARCH=aarch64     ;; \
         "linux/amd64")      S6_ARCH=amd64       ;; \
@@ -62,6 +63,10 @@ RUN apk --no-cache add socat openssl util-linux htop tzdata curl && \
     curl -sS -L -o /tmp/s6-overlay-installer "https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-${S6_ARCH}-installer" && \
     chmod +x /tmp/s6-overlay-installer && \
     /tmp/s6-overlay-installer / && \
-    rm -f /tmp/s6-overlay-installer
+    rm -f /tmp/s6-overlay-installer && \
+    mkdir /var/run/s6 && \
+    chown haproxy:haproxy /var/run/s6 && \
+    chmod ug+rwx /var/run/s6 && \
+    sed -i 's/ root / haproxy /g' /etc/s6/init/init-stage2-fixattrs.txt
 
 ENTRYPOINT ["/start.sh"]

--- a/fs/etc/cont-init.d/01-aux-cfg
+++ b/fs/etc/cont-init.d/01-aux-cfg
@@ -1,0 +1,7 @@
+#!/usr/bin/with-contenv sh
+
+if [ ! -e /etc/haproxy/haproxy-aux.cfg ]; then
+	touch /etc/haproxy/haproxy-aux.cfg
+	chgrp haproxy /etc/haproxy/haproxy-aux.cfg
+	chmod g+w /etc/haproxy/haproxy-aux.cfg
+fi

--- a/fs/etc/services.d/haproxy/run
+++ b/fs/etc/services.d/haproxy/run
@@ -1,0 +1,4 @@
+#!/usr/bin/execlineb -P
+
+with-contenv
+/usr/local/sbin/haproxy -W -db -f /etc/haproxy/haproxy.cfg -f /etc/haproxy/haproxy-aux.cfg -x /var/run/haproxy-runtime-api.sock

--- a/fs/etc/services.d/haproxy/run
+++ b/fs/etc/services.d/haproxy/run
@@ -1,4 +1,4 @@
 #!/usr/bin/execlineb -P
 
 with-contenv
-/usr/local/sbin/haproxy -W -db -f /etc/haproxy/haproxy.cfg -f /etc/haproxy/haproxy-aux.cfg -x /var/run/haproxy-runtime-api.sock
+/usr/local/sbin/haproxy -W -db -f /etc/haproxy/haproxy.cfg -f /etc/haproxy/haproxy-aux.cfg

--- a/fs/etc/services.d/ingress-controller/run
+++ b/fs/etc/services.d/ingress-controller/run
@@ -1,0 +1,3 @@
+#!/usr/bin/with-contenv sh
+
+exec /haproxy-ingress-controller --with-s6-overlay ${EXTRA_OPTIONS}

--- a/fs/start.sh
+++ b/fs/start.sh
@@ -19,6 +19,7 @@ set -e
 if [ $# -gt 0 ] && [ "$(echo $1 | cut -b1-2)" != "--" ]; then
     # Probably a `docker run -ti`, so exec and exit
     exec "$@"
-else
-    exec /haproxy-ingress-controller "$@"
 fi
+
+export EXTRA_OPTIONS="$@"
+exec /init


### PR DESCRIPTION
Run target platform specific s6 installer in image and add HAProxy and
Ingress Controller services as s6-supervised services. Make sure to pass
ENTRYPOINT arguments to IC to align with pre-s6 behaviour.