### PR TITLE
change backend names to be able to split it and use the port number

### DIFF
--- a/controller/service/service.go
+++ b/controller/service/service.go
@@ -92,9 +92,9 @@ func (s *SvcContext) GetBackendName() (string, error) {
 	}
 	s.path.SvcPortResolved = &svcPort
 	if svcPort.Name != "" {
-		s.backendName = fmt.Sprintf("%s-%s-%s", s.service.Namespace, s.service.Name, svcPort.Name)
+		s.backendName = fmt.Sprintf("%s_%s_%s_%s", s.service.Namespace, s.service.Name, strconv.Itoa(int(svcPort.Port)), svcPort.Name)
 	} else {
-		s.backendName = fmt.Sprintf("%s-%s-%s", s.service.Namespace, s.service.Name, strconv.Itoa(int(svcPort.Port)))
+		s.backendName = fmt.Sprintf("%s_%s_%s", s.service.Namespace, s.service.Name, strconv.Itoa(int(svcPort.Port)))
 	}
 	return s.backendName, nil
 }


### PR DESCRIPTION
Use underscore instead of hyphen and always include the port number for backend names.

This will be useful to integrate with linkerd but potentially also with other tools. The indended way to make use of this is by setting an annotation in the global config map.

```yaml
backend-config-snippet: |
  http-request set-header l5d-dst-override %[be_name,field(2,_)].%[be_name,field(1,_)].svc.cluster.local:%[be_name,field(3,_)]
```

#364 

Signed-off-by: Nico Braun <rainbowstack@gmail.com>