### PR TITLE
FIX/SMALL: process template strings in "updating status of ingress..." log 

### DIFF
--- a/controller/status/ingress.go
+++ b/controller/status/ingress.go
@@ -79,7 +79,7 @@ func getServiceAddresses(service *corev1.Service, curAddr *[]string) (updated bo
 }
 
 func updateIngressStatus(client *kubernetes.Clientset, ingress *store.Ingress, addresses []string) (err error) {
-	logger.Trace("Updating status of Ingress %s/%s", ingress.Namespace, ingress.Name)
+	logger.Tracef("Updating status of Ingress %s/%s", ingress.Namespace, ingress.Name)
 	var lbi []corev1.LoadBalancerIngress
 	for _, addr := range addresses {
 		if net.ParseIP(addr) == nil {


### PR DESCRIPTION
this passes the arguments through fmt.Sprintf to create meaningful log line. 

resolves https://github.com/haproxytech/kubernetes-ingress/issues/373 