### PR TITLE
BUG/MINOR: Prevent crash when POD_NAME is not correctly formatted

### DIFF
--- a/controller/utils/utils.go
+++ b/controller/utils/utils.go
@@ -118,6 +118,9 @@ func GetBoolValue(dataValue, dataName string) (result bool, err error) {
 
 func GetPodPrefix(podName string) string {
 	i := strings.LastIndex(podName, "-")
+	if i == -1 {
+		return ""
+	}
 	i = strings.LastIndex(string([]rune(podName)[:i]), "-")
 	return string([]rune(podName)[:i])
 }


### PR DESCRIPTION
pod_name is expected to be:
Pod: `<DeploymentName>-<ReplicaSetName>-<RandomString>`

However, when the IC is ran externally the POD_NAME is usually "". 