### PR TITLE
MINOR: use undercore instead of hyphen for backend names

### DIFF
--- a/controller/service/service.go
+++ b/controller/service/service.go
@@ -98,9 +98,9 @@ func (s *SvcContext) GetBackendName() (name string, err error) {
 	}
 	s.path.SvcPortResolved = &svcPort
 	if svcPort.Name != "" {
-		name = fmt.Sprintf("%s-%s-%s", s.service.Namespace, s.service.Name, svcPort.Name)
+		name = fmt.Sprintf("%s_%s_%s", s.service.Namespace, s.service.Name, svcPort.Name)
 	} else {
-		name = fmt.Sprintf("%s-%s-%s", s.service.Namespace, s.service.Name, strconv.Itoa(int(svcPort.Port)))
+		name = fmt.Sprintf("%s_%s_%s", s.service.Namespace, s.service.Name, strconv.Itoa(int(svcPort.Port)))
 	}
 	return
 }


### PR DESCRIPTION
Signed-off-by: Nico Braun <rainbowstack@gmail.com>