### PR TITLE
BUILD/MINOR: ci: build nightly images only on original repo

### DIFF
--- a/.github/workflows/docker_nightly.yml
+++ b/.github/workflows/docker_nightly.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   main:
+    if: ${{ github.repository_owner == 'haproxytech' }}
     runs-on: ubuntu-latest
     env:
       DOCKER_PLATFORMS: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/386


### PR DESCRIPTION
this action tries to create and push build even in forks
and that will not work due to credentials