### PR TITLE
Use slice instead of static sized arrays.

### DIFF
--- a/controller/monitor.go
+++ b/controller/monitor.go
@@ -193,8 +193,7 @@ func (c *HAProxyController) getWhitelistedNamespaces() []string {
 	if len(c.Store.NamespacesAccess.Whitelist) == 0 {
 		return []string{""}
 	}
-	// Add one because of potential whitelisting of configmap namespace
-	namespaces := make([]string, len(c.Store.NamespacesAccess.Whitelist)+1)
+	namespaces := []string{}
 	for ns := range c.Store.NamespacesAccess.Whitelist {
 		namespaces = append(namespaces, ns)
 	}


### PR DESCRIPTION
Since whitelisted namespaces were being appended anyways, the first entries in the
namespaces were all empty strings thus causing ingress controller to access
k8s resources on a cluster level unnecessary.