### PR TITLE
BUG/MINOR: Fix parsing for load balancing algorithm parameters

### DIFF
--- a/controller/annotations/service/loadbalance.go
+++ b/controller/annotations/service/loadbalance.go
@@ -52,7 +52,7 @@ func getParamsFromInput(value string) (*models.Balance, error) {
 		return nil, fmt.Errorf("missing algorithm name")
 	}
 
-	reg := regexp.MustCompile(`(\\(|\\))"`)
+	reg := regexp.MustCompile(`(\(|\))`)
 	algorithmTokens := reg.Split(tokens[0], -1)
 	algorithm := algorithmTokens[0]
 	balance.Algorithm = &algorithm


### PR DESCRIPTION
When using annotation for load balancing algorithm with parameters, the arguments were not parsed correctly for "hdr", "random" and "rdp-cookie" due to wrong regex.

This was mentioned in #104 and marked as fixed, but currently works only for url_param. 

What is the problem:

    value := "hdr(test_header)"
    tokens := strings.Split(value, " ")
    reg := regexp.MustCompile("(\\(|\\))")
    algorithmTokens := reg.Split(tokens[0], -1)
    fmt.Println("Proposal:", algorithmTokens, "length:", len(algorithmTokens))

    reg = regexp.MustCompile(`(\\(|\\))"`)
    algorithmTokens = reg.Split(tokens[0], -1)
    fmt.Println("Original:",algorithmTokens, "length:", len(algorithmTokens))

Output:

    Proposal: [hdr test_header ] length: 3
    Original: [hdr(test_header)] length: 1