### PR TITLE
MINOR: allow custom ports for local peer, stats and healthz

### DIFF
--- a/fs/usr/local/etc/haproxy/haproxy.cfg
+++ b/fs/usr/local/etc/haproxy/haproxy.cfg
@@ -36,7 +36,7 @@ frontend healthz
 
 frontend stats
    mode http
-   bind *:1024
+   bind *:1024 name stats
    http-request set-var(txn.base) base
    http-request use-service prometheus-exporter if { path /metrics }
    stats enable

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -171,13 +171,14 @@ func (c *HAProxyController) updateHAProxy() {
 
 // setToRready exposes readiness endpoint
 func (c *HAProxyController) setToReady() {
+	healthzPort := c.osArgs.HealthzBindPort
 	logger.Panic(c.clientAPIClosure(func() error {
 		return c.haproxy.FrontendBindEdit("healthz",
 			models.Bind{
 				BindParams: models.BindParams{
 					Name: "v4",
 				},
-				Address: "0.0.0.0:1042",
+				Address: fmt.Sprintf("0.0.0.0:%d", healthzPort),
 			})
 	}))
 	if !c.osArgs.DisableIPV6 {
@@ -188,10 +189,33 @@ func (c *HAProxyController) setToReady() {
 						Name: "v6",
 						V4v6: true,
 					},
-					Address: ":::1042",
+					Address: fmt.Sprintf(":::%d", healthzPort),
 				})
 		}))
 	}
+
+	logger.Panic(c.clientAPIClosure(func() error {
+		ip := "127.0.0.1"
+		return c.haproxy.PeerEntryEdit("localinstance",
+			models.PeerEntry{
+				Name:    "local",
+				Address: &ip,
+				Port:    &c.osArgs.LocalPeerPort,
+			},
+		)
+	}))
+
+	logger.Panic(c.clientAPIClosure(func() error {
+		return c.haproxy.FrontendBindEdit("stats",
+			models.Bind{
+				BindParams: models.BindParams{
+					Name: "stats",
+				},
+				Address: fmt.Sprintf("*:%d", c.osArgs.StatsBindPort),
+			},
+		)
+	}))
+
 	logger.Debugf("healthz frontend exposed for readiness probe")
 	cm := c.store.ConfigMaps.Main
 	if cm.Name != "" && !cm.Loaded {

--- a/pkg/haproxy/api/api.go
+++ b/pkg/haproxy/api/api.go
@@ -59,6 +59,7 @@ type HAProxyClient interface {
 	GlobalPushConfiguration(models.Global) error
 	GlobalCfgSnippet(snippet []string) error
 	GetMap(mapFile string) (*models.Map, error)
+	PeerEntryEdit(peerSection string, peer models.PeerEntry) error
 	RefreshBackends() (deleted []string, err error)
 	SetMapContent(mapFile string, payload []string) error
 	SetServerAddr(backendName string, serverName string, ip string, port int) error

--- a/pkg/haproxy/api/frontend.go
+++ b/pkg/haproxy/api/frontend.go
@@ -224,3 +224,12 @@ func (c *clientNative) FrontendRuleDeleteAll(frontend string) {
 	}
 	// No usage of TCPResponseRules yet.
 }
+
+func (c *clientNative) PeerEntryEdit(peerSection string, peerEntry models.PeerEntry) error {
+	configuration, err := c.nativeAPI.Configuration()
+	if err != nil {
+		return err
+	}
+	c.activeTransactionHasChanges = true
+	return configuration.EditPeerEntry(peerEntry.Name, peerSection, &peerEntry, c.activeTransaction, 0)
+}

--- a/pkg/utils/flags.go
+++ b/pkg/utils/flags.go
@@ -94,6 +94,9 @@ type OSArgs struct { //nolint:maligned
 	HTTPSBindPort              int64          `long:"https-bind-port" default:"443" description:"port to listen on for HTTPS traffic"`
 	IPV4BindAddr               string         `long:"ipv4-bind-address" default:"0.0.0.0" description:"IPv4 address the Ingress Controller listens on (if enabled)"`
 	IPV6BindAddr               string         `long:"ipv6-bind-address" default:"::" description:"IPv6 address the Ingress Controller listens on (if enabled)"`
+	HealthzBindPort            int64          `long:"healthz-bind-port" default:"1042" description:"port to listen on for probes"`
+	StatsBindPort              int64          `long:"stats-bind-port" default:"1024" description:"port to listen on for stats page"`
+	LocalPeerPort              int64          `long:"localpeer-port" default:"10000" description:"port to listen on for local peer"`
 	Program                    string         `long:"program" description:"path to HAProxy program. NOTE: works only with External mode"`
 	CfgDir                     string         `long:"config-dir" description:"path to HAProxy configuration directory. NOTE: works only in External mode"`
 	RuntimeDir                 string         `long:"runtime-dir" description:"path to HAProxy runtime directory. NOTE: works only in External mode"`


### PR DESCRIPTION
Currently, it is not possible to simultaneously run two **host-mode** ingress controllers on the same node, because the binds `127.0.0.1:10000` ([local peer](https://github.com/haproxytech/kubernetes-ingress/blob/9e4371177f86bc48c63e79c56968a4f459666ae4/fs/usr/local/etc/haproxy/haproxy.cfg#L17)), `*:1024` ([stats](https://github.com/haproxytech/kubernetes-ingress/blob/9e4371177f86bc48c63e79c56968a4f459666ae4/fs/usr/local/etc/haproxy/haproxy.cfg#L39)), and `0.0.0.0:1042` ([health](https://github.com/haproxytech/kubernetes-ingress/blob/9e4371177f86bc48c63e79c56968a4f459666ae4/fs/usr/local/etc/haproxy/haproxy.cfg#L32)) are hardcoded.

This PR allows using custom ports for local peer, stats and healthz.

Fixes #348

---

Considering some minor API changes between 1.7 and master, I backported this change to 1.6 and 1.7 branches as well (#448, #447)
