### PR TITLE
Allow custom ports for local peer, stats and healthz (1.6 backport)

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -15,6 +15,7 @@
 package controller
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -254,11 +255,12 @@ func (c *HAProxyController) updateHAProxy() {
 
 // setToRready exposes readiness endpoint
 func (c *HAProxyController) setToReady() {
+	healthzPort := c.OSArgs.HealthzBindPort
 	logger.Panic(c.clientAPIClosure(func() error {
 		return c.Client.FrontendBindEdit("healthz",
 			models.Bind{
 				Name:    "v4",
-				Address: "0.0.0.0:1042",
+				Address: fmt.Sprintf("0.0.0.0:%d", healthzPort),
 			})
 	}))
 	if !c.OSArgs.DisableIPV6 {
@@ -266,12 +268,33 @@ func (c *HAProxyController) setToReady() {
 			return c.Client.FrontendBindCreate("healthz",
 				models.Bind{
 					Name:    "v6",
-					Address: ":::1042",
+					Address: fmt.Sprintf(":::%d", healthzPort),
 					V4v6:    true,
 				})
 		}))
 	}
 	logger.Debugf("healthz frontend exposed for readiness probe")
+
+	logger.Panic(c.clientAPIClosure(func() error {
+		ip := "127.0.0.1"
+		return c.Client.PeerEntryEdit("local", "localinstance",
+			models.PeerEntry{
+				Name:    "local",
+				Address: &ip,
+				Port:    &c.OSArgs.LocalPeerPort,
+			},
+		)
+	}))
+
+	logger.Panic(c.clientAPIClosure(func() error {
+		return c.Client.FrontendBindEdit("stats",
+			models.Bind{
+				Name:    "stats",
+				Address: fmt.Sprintf("*:%d", c.OSArgs.StatsBindPort),
+			},
+		)
+	}))
+
 	cm := c.Store.ConfigMaps.Main
 	if cm.Name != "" && !cm.Loaded {
 		logger.Warningf("Main configmap '%s/%s' not found", cm.Namespace, cm.Name)

--- a/controller/haproxy/api/api.go
+++ b/controller/haproxy/api/api.go
@@ -59,6 +59,7 @@ type HAProxyClient interface {
 	PIDFile(value *types.StringC) error
 	RuntimeSocket(value *types.Socket) error
 	GetMap(mapFile string) (*models.Map, error)
+	PeerEntryEdit(name string, peerSection string, peer models.PeerEntry) error
 	SetMapContent(mapFile string, payload string) error
 	ServerStateBase(value *types.StringC) error
 	SetServerAddr(backendName string, serverName string, ip string, port int) error

--- a/controller/haproxy/api/frontend.go
+++ b/controller/haproxy/api/frontend.go
@@ -154,3 +154,8 @@ func (c *clientNative) FrontendRuleDeleteAll(frontend string) {
 	}
 	// No usage of TCPResponseRules yet.
 }
+
+func (c *clientNative) PeerEntryEdit(name string, peerSection string, peer models.PeerEntry) error {
+	c.activeTransactionHasChanges = true
+	return c.nativeAPI.Configuration.EditPeerEntry(name, peerSection, &peer, c.activeTransaction, 0)
+}

--- a/controller/utils/flags.go
+++ b/controller/utils/flags.go
@@ -94,6 +94,9 @@ type OSArgs struct { //nolint:maligned
 	HTTPSBindPort              int64          `long:"https-bind-port" default:"443" description:"port to listen on for HTTPS traffic"`
 	IPV4BindAddr               string         `long:"ipv4-bind-address" default:"0.0.0.0" description:"IPv4 address the Ingress Controller listens on (if enabled)"`
 	IPV6BindAddr               string         `long:"ipv6-bind-address" default:"::" description:"IPv6 address the Ingress Controller listens on (if enabled)"`
+	HealthzBindPort            int64          `long:"healthz-bind-port" default:"1042" description:"port to listen on for probes"`
+	StatsBindPort              int64          `long:"stats-bind-port" default:"1024" description:"port to listen on for stats page"`
+	LocalPeerPort              int64          `long:"localpeer-port" default:"10000" description:"port to listen on for local peer"`
 	Program                    string         `long:"program" description:"path to HAProxy program. NOTE: works only with External mode"`
 	CfgDir                     string         `long:"config-dir" description:"path to HAProxy configuration directory. NOTE: works only in External mode"`
 	RuntimeDir                 string         `long:"runtime-dir" description:"path to HAProxy runtime directory. NOTE: works only in External mode"`

--- a/fs/usr/local/etc/haproxy/haproxy.cfg
+++ b/fs/usr/local/etc/haproxy/haproxy.cfg
@@ -58,7 +58,7 @@ frontend healthz
 
 frontend stats
    mode http
-   bind *:1024
+   bind *:1024 name stats
    http-request set-var(txn.base) base
    http-request use-service prometheus-exporter if { path /metrics }
    stats enable


### PR DESCRIPTION
This PR backports #446 to v1.6 branch.

----

Currently, it is not possible to simultaneously run two host-mode ingress controllers on the same node, because the binds `127.0.0.1:10000` (local peer), `*:1024` (stats), and `0.0.0.0:1042` (healthz) are hardcoded.

This PR allows using custom ports for local peer, stats and healthz.

Fixes #348