### PR TITLE
Allow custom ports for local peer, stats and healthz (1.7 backport)

### DIFF
--- a/controller/haproxy/api/api.go
+++ b/controller/haproxy/api/api.go
@@ -52,6 +52,7 @@ type HAProxyClient interface {
 	GlobalPushConfiguration(models.Global) error
 	GlobalCfgSnippet(snippet []string) error
 	GetMap(mapFile string) (*models.Map, error)
+	PeerEntryEdit(name string, peerSection string, peer models.PeerEntry) error
 	SetMapContent(mapFile string, payload string) error
 	SetServerAddr(backendName string, serverName string, ip string, port int) error
 	SetServerState(backendName string, serverName string, state string) error

--- a/controller/haproxy/api/frontend.go
+++ b/controller/haproxy/api/frontend.go
@@ -156,3 +156,8 @@ func (c *clientNative) FrontendRuleDeleteAll(frontend string) {
 	}
 	// No usage of TCPResponseRules yet.
 }
+
+func (c *clientNative) PeerEntryEdit(name string, peerSection string, peer models.PeerEntry) error {
+	c.activeTransactionHasChanges = true
+	return c.nativeAPI.Configuration.EditPeerEntry(name, peerSection, &peer, c.activeTransaction, 0)
+}

--- a/controller/utils/flags.go
+++ b/controller/utils/flags.go
@@ -94,6 +94,9 @@ type OSArgs struct { //nolint:maligned
 	HTTPSBindPort              int64          `long:"https-bind-port" default:"443" description:"port to listen on for HTTPS traffic"`
 	IPV4BindAddr               string         `long:"ipv4-bind-address" default:"0.0.0.0" description:"IPv4 address the Ingress Controller listens on (if enabled)"`
 	IPV6BindAddr               string         `long:"ipv6-bind-address" default:"::" description:"IPv6 address the Ingress Controller listens on (if enabled)"`
+	HealthzBindPort            int64          `long:"healthz-bind-port" default:"1042" description:"port to listen on for probes"`
+	StatsBindPort              int64          `long:"stats-bind-port" default:"1024" description:"port to listen on for stats page"`
+	LocalPeerPort              int64          `long:"localpeer-port" default:"10000" description:"port to listen on for local peer"`
 	Program                    string         `long:"program" description:"path to HAProxy program. NOTE: works only with External mode"`
 	CfgDir                     string         `long:"config-dir" description:"path to HAProxy configuration directory. NOTE: works only in External mode"`
 	RuntimeDir                 string         `long:"runtime-dir" description:"path to HAProxy runtime directory. NOTE: works only in External mode"`

--- a/fs/usr/local/etc/haproxy/haproxy.cfg
+++ b/fs/usr/local/etc/haproxy/haproxy.cfg
@@ -36,7 +36,7 @@ frontend healthz
 
 frontend stats
    mode http
-   bind *:1024
+   bind *:1024 name stats
    http-request set-var(txn.base) base
    http-request use-service prometheus-exporter if { path /metrics }
    stats enable


### PR DESCRIPTION
This PR backports #446 to v1.7 branch.

----

Currently, it is not possible to simultaneously run two host-mode ingress controllers on the same node, because the binds `127.0.0.1:10000` (local peer), `*:1024` (stats), and `0.0.0.0:1042` (healthz) are hardcoded.

This PR allows using custom ports for local peer, stats and healthz.

Fixes #348