### PR TITLE
BUG/MINOR: prevent unconditional override of http-server-close annotation

### DIFF
--- a/pkg/annotations/global/option.go
+++ b/pkg/annotations/global/option.go
@@ -31,7 +31,9 @@ func (a *Option) Process(k store.K8s, annotations ...map[string]string) error {
 	if input == "" {
 		switch a.name {
 		case "http-server-close", "http-keep-alive":
-			a.defaults.HTTPConnectionMode = ""
+			if a.defaults.HTTPConnectionMode == a.name {
+				a.defaults.HTTPConnectionMode = ""
+			}
 		case "dontlognull":
 			a.defaults.Dontlognull = ""
 		case "logasap":
@@ -62,7 +64,9 @@ func (a *Option) Process(k store.K8s, annotations ...map[string]string) error {
 	} else {
 		switch a.name {
 		case "http-server-close", "http-keep-alive":
-			a.defaults.HTTPConnectionMode = ""
+			if a.defaults.HTTPConnectionMode == a.name {
+				a.defaults.HTTPConnectionMode = ""
+			}
 		case "dontlognull":
 			a.defaults.Dontlognull = "disabled"
 		case "logasap":


### PR DESCRIPTION
After version 1.7.0, you cannot use the `http-server-close` annotation, as it will always be ignored by the controller in favor of the `http-keep-alive` annotation, even if `http-keep-alive` is empty, undefined, or `'false'`.

Both the `http-keep-alive` and `http-server-close` annotations change the value of `defaults.HTTPConnectionMode`. But since the `http-keep-alive` annotation is evaluated last, it overwrites whatever value `http-server-close` has previously set.

In this PR, the value of `defaults.HTTPConnectionMode` will only be changed if its value matches the evaluated annotation.

----

Perhaps it might be better to merge these annotations into one since they are mutually exclusive. After all, if you set `http-keep-alive: 'false'`, you won't get the expected result: no options will be set and the default will be used, which **is keep-alive**. Also, a third alternative is not supported via annotations (`httpclose`).

So, I think it might be better to have a `http-connection-mode` annotation, whose values could be: `http-keep-alive` (default), `http-server-close`, `httpclose`. Something like #457.
