### PR TITLE
BUG/MINOR: using more than one syslog server always leads to unnecessary restarts

### DIFF
--- a/pkg/annotations/global/syslogServer.go
+++ b/pkg/annotations/global/syslogServer.go
@@ -35,7 +35,7 @@ func (a *SyslogServers) GetName() string {
 func (a *SyslogServers) Process(k store.K8s, annotations ...map[string]string) error {
 	input := common.GetValue(a.GetName(), annotations...)
 	a.stdout = false
-	for _, syslogLine := range strings.Split(input, "\n") {
+	for i, syslogLine := range strings.Split(input, "\n") {
 		if syslogLine == "" {
 			continue
 		}
@@ -56,7 +56,7 @@ func (a *SyslogServers) Process(k store.K8s, annotations ...map[string]string) e
 			}
 		}
 		// populate annotation data
-		logTarget := models.LogTarget{Index: utils.PtrInt64(0)}
+		logTarget := models.LogTarget{Index: utils.PtrInt64(int64(i))}
 		address, ok := logParams["address"]
 		if !ok {
 			return fmt.Errorf("incorrect syslog Line: no address param in '%s'", syslogLine)


### PR DESCRIPTION
Fixes #420

When using more than one syslog server, the algorithm for comparing log targets never succeeds, because the conversion of each `syslog-server` annotation's line into a `models.LogTarget` will always set the `.Index` field equal to 0:

https://github.com/haproxytech/kubernetes-ingress/blob/88a9cb4a106a084c93549909f9f862afeca4de85/pkg/annotations/global/syslogServer.go#L59

In this scenario, any state change causes a restart because `lg` and `newLg` will never be equal (either because of the slice order, or because of the different `.Index` fields):

https://github.com/haproxytech/kubernetes-ingress/blob/88a9cb4a106a084c93549909f9f862afeca4de85/pkg/controller/global.go#L84-L89

## Example

ConfigMap input:
```yaml
syslog-server: |
  address:stdout, format:raw, facility:daemon, level:notice
  address:/run/shared/log, facility:local0, level:info
```

Controller output after a simple scale-up (formatted, for easier reading):
```
2022/06/02 00:41:59 DEBUG   global.go:82 Global log targets updated:
[
slice[0].Address: stdout != /run/shared/log
slice[0].Facility: daemon != local0
slice[0].Format: raw != 
slice[0].Level: notice != info

slice[1].Address: /run/shared/log != stdout
slice[1].Facility: local0 != daemon
slice[1].Format:  != raw
slice[1].Index: 0 != 1
slice[1].Level: info != notice
]
Restart required
```


