### PR TITLE
BUG/MINOR: Prevents unnecessary reloading when the attribute `client-ca` is not used.

### DIFF
--- a/pkg/handler/https.go
+++ b/pkg/handler/https.go
@@ -115,7 +115,7 @@ func (handler HTTPS) handleClientTLSAuth(k store.K8s, h haproxy.HAProxy) (reload
 	}
 
 	// No changes
-	if binds[0].SslCafile == caFile && binds[0].Verify == verify {
+	if binds[0].SslCafile == caFile && (caFile == "" || binds[0].Verify == verify) {
 		return
 	}
 	// Removing config


### PR DESCRIPTION
After commit c954b4383865a0abd7eab3b3d77fe3ed45be29aa, if you don't use `client-ca`, the comparison between `BindParams.Verify` and `client-crt-optional` will never be true, which will force an unnecessary reload of the instance every 10 minutes (the value of `cache-resync-period`).

To make the bug easier to reproduce, reduce the `cache-resync-period` time to 20 seconds and create a controller without passing the `ca-file` annotation.

If `client-ca` and `client-crt-optional` aren't used, `BindParams.Verify` will always be an empty string and therefore can't be equal to `"required"`.

https://github.com/haproxytech/kubernetes-ingress/blob/3d8a6874e328b9cb0febae1040bc3f3b7eb4b0c3/pkg/handler/https.go#L110-L120

So, if `client-ca` and `BindParams.SslCafile` are equal and **both are empty**, we don't need to check the value of the `Verify` attribute. In this case, we can safely skip the reload because if `client-ca` didn't change (`binds[0].SslCafile == caFile`) **and** is still empty (`caFile == ""`), the `Verify` value doesn't matter.
