### PR TITLE
BUG/MINOR: triggers a reload if an Ingress is deleted

### DIFF
--- a/pkg/handler/refresh.go
+++ b/pkg/handler/refresh.go
@@ -39,6 +39,7 @@ func (handler Refresh) Update(k store.K8s, h haproxy.HAProxy, a annotations.Anno
 	reload = h.RefreshMaps(h.HAProxyClient) || reload
 	// Backends
 	deleted, err := h.RefreshBackends()
+	reload = len(deleted) > 0 || reload
 	logger.Error(err)
 	for _, backend := range deleted {
 		logger.Debugf("Backend '%s' deleted", backend)


### PR DESCRIPTION
**Important**: To reproduce this bug, we first need to get away from bug #455. To do so, apply that patch or pass a `client-ca` certificate, otherwise, the reload will be triggered (but for other reasons explained in that PR).

If you delete an Ingress and the method `HAProxy.RefreshRules` doesn't trigger a reload, the backend will be kept on HAProxy.

To reproduce, create two or more ingresses with the same set of rules (`ssl-redirect: "true"`, for example, or no rules at all). Then delete one of them and see that the reload will not be triggered.

This was caused partially by commit 2f200cf43 `OPTIM: Enable dynamic update of HAProxy map files`. It disabled the update via reloads in favor of dynamic map update (which is great, by the way), but did not handle ingress deletion cases.