### PR TITLE
BUG/MINOR: don't add cookie to server if dynamic cookie enabled

### DIFF
--- a/pkg/service/endpoints.go
+++ b/pkg/service/endpoints.go
@@ -70,10 +70,6 @@ func (s *Service) updateHAProxySrv(client api.HAProxyClient, srvSlot store.HAPro
 		srv.Address = srvSlot.Address
 		srv.Maintenance = "disabled"
 	}
-	// Cookie/Session persistence
-	if s.backend.Cookie != nil && s.backend.Cookie.Type == "insert" {
-		srv.Cookie = srv.Name
-	}
 	logger.Tracef("backend %s: about to update server in configuration file :  models.Server { Name: %s, Port: %d, Address: %s, Maintenance: %s }", s.backend.Name, srv.Name, *srv.Port, srv.Address, srv.Maintenance)
 	// Update server
 	errAPI := client.BackendServerEdit(s.backend.Name, srv)


### PR DESCRIPTION
the annotation `haproxy.org/cookie-persistence` is supposed to enable dynamic cookies for the backend, but i've found that it is still returning static cookies.

I tested with 1.7.9 and 1.8.0 and see the same behavior. If I define an ingress with the annotation

```
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: test
  namespace: test
  annotations:
    haproxy.org/cookie-persistence: "COOKIE"
```

The generated backend configuration looks like the following. Note the dynamic cookie option and key is set, but the server entries each specify a cookie (`SRV_1` and `SRV_2`). If cookies are present on the servers, it disables the dynamic mode.

```
backend test_app_http
  mode http
  balance roundrobin
  option forwardfor
  no option abortonclose
  default-server check
  cookie COOKIE dynamic indirect nocache insert
  dynamic-cookie-key ohph7OoGhong
  server SRV_1 100.65.210.25:80 enabled cookie SRV_1
  server SRV_2 100.64.16.185:80 enabled cookie SRV_2
```

the cookie that is returned is the static cookie, like this:
```
set-cookie: COOKIE=SRV_1; path=/
```
or this
```
set-cookie: COOKIE=SRV_2; path=/
```

When running multiple haproxy pods, this has resulted in clients being sent to the incorrect server, if the order of the servers is different in each pod.

This change changes the logic so that it will not add a cookie to the server entries if the `dynamic` option is set.

Using the same ingress configuration with the patched version results in this backend configuration, without a cookie set on the servers

```
backend test_app_http
  mode http
  balance roundrobin
  option forwardfor
  no option abortonclose
  default-server check
  cookie COOKIE dynamic indirect nocache insert
  dynamic-cookie-key ohph7OoGhong
  server SRV_1 100.64.16.185:80 enabled
  server SRV_2 100.65.210.25:80 enabled
```

The cookies that are returned are now the expected dynamic values generated from a hash of the server addresses:

```
set-cookie: COOKIE=d257e60a895117a1; path=/
```
and
```
set-cookie: COOKIE=a2960a4362d3f17f; path=/
```