### PR TITLE
BUG/MINOR: Prevents unnecessary reloads when `cookie-persistence` is enabled.

### DIFF
--- a/pkg/annotations/service/cookie.go
+++ b/pkg/annotations/service/cookie.go
@@ -36,6 +36,7 @@ func (a *Cookie) Process(k store.K8s, annotations ...map[string]string) error {
 		Nocache:  true,
 		Indirect: true,
 		Dynamic:  true,
+		Domains:  []*models.Domain{},
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #459 

When a Service/Ingress/ConfigMap is configured with the annotation `cookie-persistence`, the comparison with the corresponding backend in the HAProxy settings will always fail, because the `backend.Cookie.Domain` attribute of an initialized model is a `<nil slice>` and the corresponding value returned by HAProxy is an empty array.

```text
service/service.go:134 Service 'exemplo/bazaar': backend 'exemplo_bazaar_http' updated: [Cookie.Domains: <nil slice> != []]
Reload required
```