### PR TITLE
MINOR: add a `tune_options` attribute to the Global CRD

### DIFF
--- a/crs/definition/global.yaml
+++ b/crs/definition/global.yaml
@@ -127,6 +127,12 @@ spec:
                         param:
                           type: string
                           pattern: '^[^\s]+$'
+                    tune_options:
+                      type: object
+                      properties:
+                        bufsize:
+                          type: integer
+
                 log_targets:
                   type: array
                   items:


### PR DESCRIPTION
When using a global CRD, every state change triggers a hard restart on HAProxy (even a simple pod scale):

```text
2022/08/03 16:20:49 DEBUG   global.go:81 Global config updated: [TuneOptions: <nil pointer> != models.GlobalTuneOptions]
Restart required
```

Since `TuneOptions` is not defined in the `core.haproxy.orgGlobal` CRD, unmarshalling it always returns a `models.Global` object with `.TuneOptions` attribute equals to `<nil>`.

When requesting global settings from HAProxy, the `client.GlobalGetConfiguration` method returns a `models.Global` object with `.TuneOptions` attribute equal to a `models.GlobalTuneOptions` object.

When comparing both, `<nil>` can never equal `models.GlobalTuneOptions`, and the IC schedules a hard restart on every sync attempt.

This PR adds a `tune_options` attribute to the Global CRD. I just added a single attribute (`bufsize`, but any other would work) because it's enough to fix this bug. Should I implement them all?
