### PR TITLE
BUG/MINOR: avoid hard restarts when using a Global CRD

### DIFF
--- a/pkg/haproxy/env/defaults.go
+++ b/pkg/haproxy/env/defaults.go
@@ -45,6 +45,9 @@ func SetGlobal(global *models.Global, logTargets *models.LogTargets, env Env) {
 	if global.SslDefaultBindOptions == "" {
 		global.SslDefaultBindOptions = "no-sslv3 no-tls-tickets no-tlsv10"
 	}
+	if global.TuneOptions == nil {
+		global.TuneOptions = &models.GlobalTuneOptions{}
+	}
 	if len(*logTargets) == 0 {
 		*logTargets = []*models.LogTarget{{
 			Index:    utils.PtrInt64(0),


### PR DESCRIPTION
When using a global CRD, every state change triggers a hard restart on HAProxy (even a simple pod scale):

```text
2022/08/03 16:20:49 DEBUG   global.go:81 Global config updated: [TuneOptions: <nil pointer> != models.GlobalTuneOptions]
Restart required
```

When synchronizing a `core.haproxy.org.Global` resource, the comparison with the corresponding settings in the HAProxy will always fail, because the `TuneOptions` attribute of an initialized `models.Global` is a `<nil pointer>` and the corresponding value returned by HAProxy is an empty `models.GlobalTuneOptions`.

This PR sets an empty `models.GlobalTuneOptions` as default value of `global.TuneOptions` attribute to prevent unnecessary restarts.
