### PR TITLE
BUG/MINOR: remove newline if present in server state file

### DIFF
--- a/pkg/haproxy/process/interface.go
+++ b/pkg/haproxy/process/interface.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"os"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/haproxytech/client-native/v3/runtime"
@@ -74,7 +75,9 @@ func saveServerState(stateDir string, api runtime.Raw) error {
 		return err
 	}
 	defer f.Close()
-	if _, err = f.Write([]byte(result[0])); err != nil {
+	// remove leading new line if exists
+	state := strings.TrimPrefix(result[0], "\n")
+	if _, err = f.Write([]byte(state)); err != nil {
 		logger.Error(err)
 		return err
 	}


### PR DESCRIPTION
We use [load-server-state-from-file](http://cbonte.github.io/haproxy-dconv/2.6/configuration.html#load-server-state-from-file).

When these reloads occur (e.g. when an ingress is applied), we see the following logged:
```
config: Can't get version of the global server state file '/var/state/haproxy/global'.
```

When we dug deeper into server_state.c in HAProxy where this error is logged, we see the following
```
 /* first character of first line of the file must contain the version of the export */
 local_vsn = srv_state_get_version(f);
 if (local_vsn == 0) {
     ha_warning("Proxy '%s': Can't get version of the server state file '%s'.\n",
            curproxy->id, file);
     goto close_localfile;
 }
```
When I exec into the pod, I confirmed that the first line of the `/var/state/haproxy/global` is an empty line.
```
/ # head -n 2 /var/state/haproxy/global

1
```
So this feels like it would mean that we can neither grab, nor persist state for reloads.

This PR adds similar cleanup to how [`client-native`](https://github.com/haproxytech/client-native) [does it](https://github.com/haproxytech/client-native/blob/3c347479f6f628343c6dfd8b780797c2892b36e2/runtime/servers.go#L133) for this code.