### PR TITLE
Remove unecessary information from whitelist/blacklist address format…

### DIFF
--- a/pkg/annotations/ingress/accessControl.go
+++ b/pkg/annotations/ingress/accessControl.go
@@ -58,7 +58,7 @@ func (a *AccessControl) Process(k store.K8s, annotations ...map[string]string) (
 			address = strings.TrimSpace(address)
 			if ip := net.ParseIP(address); ip == nil {
 				if _, _, err := net.ParseCIDR(address); err != nil {
-					return fmt.Errorf("incorrect address '%s' in blacklist annotation'", address)
+					return fmt.Errorf("incorrect address '%s' in %s annotation", address, a.name)
 				}
 			}
 			a.maps.MapAppend(mapName, address)


### PR DESCRIPTION
Corrects issue #519 
here is the output of the error:
annotation blacklist: incorrect address '192.168.1.0-24' in blacklist annotation'
annotation whitelist: incorrect address '192.168.1.0-24' in blacklist annotation'

We already have the information in the beginning of the error