### PR TITLE
BUG/MINOR: quit after printing version when invoked with -v

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,7 +71,10 @@ func main() {
 		return
 	}
 	logger.ShowFilename(false)
-	logInfo(logger, osArgs)
+	exit := logInfo(logger, osArgs)
+	if exit {
+		return
+	}
 	logger.ShowFilename(true)
 
 	// backwards compatibility with 1.7
@@ -131,7 +134,7 @@ func main() {
 	close(stop)
 }
 
-func logInfo(logger utils.Logger, osArgs utils.OSArgs) {
+func logInfo(logger utils.Logger, osArgs utils.OSArgs) bool {
 	if len(osArgs.Version) > 0 {
 		fmt.Printf("HAProxy Ingress Controller %s %s%s", GitTag, GitCommit, GitDirty)
 		fmt.Printf("Build from: %s", GitRepo)
@@ -141,7 +144,7 @@ func logInfo(logger utils.Logger, osArgs utils.OSArgs) {
 			fmt.Printf("Ingress class: %s", osArgs.IngressClass)
 			fmt.Printf("Empty Ingress class: %t", osArgs.EmptyIngressClass)
 		}
-		return
+		return true
 	}
 
 	logger.Print(IngressControllerInfo)
@@ -195,6 +198,7 @@ func logInfo(logger utils.Logger, osArgs utils.OSArgs) {
 	hostname, err := os.Hostname()
 	logger.Error(err)
 	logger.Printf("Running on %s", hostname)
+	return false
 }
 
 func getNamespaceValue(name string) *utils.NamespaceValue {


### PR DESCRIPTION
It might be a misunderstanding, but my expectation of `-v` is "print version _and exit_", which is currently not the case. Feel free to close if this is intended behavior.