### PR TITLE
BUG/MEDIUM: support alternative healthcheck endpoint

### DIFF
--- a/pkg/controller/builder.go
+++ b/pkg/controller/builder.go
@@ -202,6 +202,7 @@ func addControllerMetricData(builder *Builder, chShutdown chan struct{}) {
 		runningServices += ", prometheus"
 	}
 	rtr.GET("/healtz", requestHandler)
+	rtr.GET("/healthz", requestHandler)
 	// all others will be 404
 	go func() {
 		server := fasthttp.Server{
@@ -225,6 +226,7 @@ func addControllerMetricData(builder *Builder, chShutdown chan struct{}) {
 func addLocalDefaultService(builder *Builder, chShutdown chan struct{}) {
 	rtr := router.New()
 	rtr.GET("/healtz", requestHandler)
+	rtr.GET("/healthz", requestHandler)
 	// all others will be 404
 	go func() {
 		server := fasthttp.Server{
@@ -247,5 +249,11 @@ func addLocalDefaultService(builder *Builder, chShutdown chan struct{}) {
 
 func requestHandler(ctx *fasthttp.RequestCtx) {
 	ctx.SetStatusCode(fasthttp.StatusOK)
-	ctx.Response.Header.Set("X-HAProxy-Ingress-Controller", "healtz")
+
+	switch string(ctx.Path()) {
+	case "/healthz":
+		ctx.Response.Header.Set("X-HAProxy-Ingress-Controller", "healthz")
+	default:
+		ctx.Response.Header.Set("X-HAProxy-Ingress-Controller", "healtz")
+	}
 }


### PR DESCRIPTION
Wanted to add an alternative healthcheck endpoint like the PR https://github.com/haproxytech/kubernetes-ingress/pull/536 which wasn't got merged because the owner didn't reply.

I fixed the response header also.

Feel free to add remarks if something is missing.