### PR TITLE
BUG/MINOR: avoid hard restarts when the number of endpoints reaches zero

### DIFF
--- a/pkg/store/events.go
+++ b/pkg/store/events.go
@@ -115,7 +115,7 @@ func (k *K8s) EventEndpoints(ns *Namespace, data *Endpoints, syncHAproxySrvs fun
 	endpoints := getEndpoints(ns.Endpoints[data.Service])
 	logger.Tracef("service %s : endpoints list %+v", data.Service, endpoints)
 	_, ok := ns.HAProxyRuntime[data.Service]
-	if !ok || len(endpoints) == 0 {
+	if !ok {
 		ns.HAProxyRuntime[data.Service] = make(map[string]*RuntimeBackend)
 	}
 	logger.Tracef("service %s : number of already existing backend(s) in this transaction for this endpoint: %d", data.Service, len(ns.HAProxyRuntime[data.Service]))


### PR DESCRIPTION
If the number of endpoints of a service reaches zero, the HAProxy will be restarted when this same service returns a non zero target set. This scenario happens, for example, during a deploy/rollout of a workload with `replicas: 1` or if the rolling strategy of the workload has `maxUnavailable: 100%`.

It is very easy to reproduce this bug:

```bash
# this will not restart HAProxy
k scale deployment whoami --replicas 5
k scale deployment whoami --replicas 1

# this will restart HAProxy
k scale deployment whoami --replicas 0
k scale deployment whoami --replicas 1
```

When the number of endpoints reaches zero, the `ns.HAProxyRuntime[data.Service]` variable is recreated and the check `len(backend.HAProxySrvs) < srvSlots` causes a restart:

https://github.com/haproxytech/kubernetes-ingress/blob/886db237ced6fb5c2f9cc49fe645ec9155f6d5ff/pkg/service/endpoints.go#L107-L116

This behavior was introduced by commit ceae568, which intends to keep server slots in case a change in a Service results in an empty targets set (instead of losing them). This PR keeps the goals of that commit, but without causing a forced restart when the result is no longer empty.