### PR TITLE
BUG/MINOR: prevents port conflicts on startup when using hostNetwork

### DIFF
--- a/deploy/tests/integration/base-suite.go
+++ b/deploy/tests/integration/base-suite.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 )
 
-//nolint:dupword
 var haproxyConfig = `global
 daemon
 master-worker
@@ -43,25 +42,21 @@ peers localinstance
 
 frontend https
 mode http
-bind 127.0.0.1:8080 name v4
 http-request set-var(txn.base) base
 use_backend %[var(txn.path_match),field(1,.)]
 
 frontend http
 mode http
-bind 127.0.0.1:4443 name v4
 http-request set-var(txn.base) base
 use_backend %[var(txn.path_match),field(1,.)]
 
 frontend healthz
-bind 127.0.0.1:1042 name v4
 mode http
 monitor-uri /healthz
 option dontlog-normal
 
 frontend stats
   mode http
-  bind *:1024 name stats
   stats enable
   stats uri /
   stats refresh 10s

--- a/deploy/tests/tnr/routeacl/suite_test.go
+++ b/deploy/tests/tnr/routeacl/suite_test.go
@@ -62,7 +62,6 @@ func (suite *UseBackendSuite) BeforeTest(suiteName, testName string) {
 	suite.T().Logf("temporary configuration dir %s", suite.test.TempDir)
 }
 
-//nolint:dupword
 var haproxyConfig = `global
 daemon
 master-worker
@@ -75,25 +74,21 @@ peers localinstance
 
 frontend https
 mode http
-bind 127.0.0.1:8080 name v4
 http-request set-var(txn.base) base
 use_backend %[var(txn.path_match),field(1,.)]
 
 frontend http
 mode http
-bind 127.0.0.1:4443 name v4
 http-request set-var(txn.base) base
 use_backend %[var(txn.path_match),field(1,.)]
 
 frontend healthz
-bind 127.0.0.1:1042 name v4
 mode http
 monitor-uri /healthz
 option dontlog-normal
 
 frontend stats
   mode http
-  bind *:1024 name stats
   stats enable
   stats uri /
   stats refresh 10s

--- a/fs/usr/local/etc/haproxy/haproxy.cfg
+++ b/fs/usr/local/etc/haproxy/haproxy.cfg
@@ -27,25 +27,21 @@ peers localinstance
 
 frontend https
   mode http
-  bind 127.0.0.1:8080 name v4
   http-request set-var(txn.base) base
   use_backend %[var(txn.path_match),field(1,.)]
 
 frontend http
   mode http
-  bind 127.0.0.1:4443 name v4
   http-request set-var(txn.base) base
   use_backend %[var(txn.path_match),field(1,.)]
 
 frontend healthz
-  bind 127.0.0.1:1042 name v4
   mode http
   monitor-uri /healthz
   option dontlog-normal
 
 frontend stats
    mode http
-   bind *:1024 name stats
    http-request set-var(txn.base) base
    http-request use-service prometheus-exporter if { path /metrics }
    stats enable

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -204,7 +204,7 @@ func (c *HAProxyController) updateHAProxy() {
 func (c *HAProxyController) setToReady() {
 	healthzPort := c.osArgs.HealthzBindPort
 	logger.Panic(c.clientAPIClosure(func() error {
-		return c.haproxy.FrontendBindEdit("healthz",
+		return c.haproxy.FrontendBindCreate("healthz",
 			models.Bind{
 				BindParams: models.BindParams{
 					Name: "v4",
@@ -237,7 +237,7 @@ func (c *HAProxyController) setToReady() {
 	}))
 
 	logger.Panic(c.clientAPIClosure(func() error {
-		return c.haproxy.FrontendBindEdit("stats",
+		return c.haproxy.FrontendBindCreate("stats",
 			models.Bind{
 				BindParams: models.BindParams{
 					Name: "stats",


### PR DESCRIPTION
This PR fixes #566.

Creates new binds (instead of editing them) of the `healthz` and `stats` frontends to avoid port conflicts at the first start of the HAProxy when using `hostNetwork: true`.

Since these bind directives are not required, the first start of HAProxy is not affected.

The `http` and `https` frontends were already being created before this PR.