### PR TITLE
BUG/MINOR: prevents clash on custom routes names to avoid unecessary restarts

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/go-test/deep"
+
 	"github.com/haproxytech/client-native/v3/models"
 	"github.com/haproxytech/kubernetes-ingress/pkg/annotations"
 	gateway "github.com/haproxytech/kubernetes-ingress/pkg/gateways"
@@ -138,6 +140,13 @@ func (c *HAProxyController) updateHAProxy() {
 				c.updateStatusManager.AddIngress(i)
 			}
 		}
+	}
+
+	updated := deep.Equal(route.CurentCustomRoutes, route.CustomRoutes, deep.FLAG_IGNORE_SLICE_ORDER)
+	if len(updated) != 0 {
+		route.CurentCustomRoutes = route.CustomRoutes
+		logger.Debugf("Custom Routes changed: %s, reload required", updated)
+		c.reload = true
 	}
 
 	gatewayReload := c.gatewayManager.ManageGateway()

--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -112,11 +112,6 @@ func (i *Ingress) handlePath(k store.K8s, h haproxy.HAProxy, host string, path *
 
 	routeACLAnn := a.String("route-acl", svc.GetResource().Annotations)
 	if routeACLAnn == "" {
-		if _, ok := route.CustomRoutes[backendName]; ok {
-			delete(route.CustomRoutes, backendName)
-			logger.Debugf("Custom Route to backend '%s' deleted, reload required", backendName)
-			routeReload = true
-		}
 		err = route.AddHostPathRoute(ingRoute, h.Maps)
 	} else {
 		routeReload, err = route.AddCustomRoute(ingRoute, routeACLAnn, h)

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -40,8 +40,8 @@ const (
 )
 
 var (
-	CustomRoutes = make(map[string]string)
-	logger       = utils.GetLogger()
+	CurentCustomRoutes = make([]string, 0)
+	CustomRoutes       = make([]string, 0)
 )
 
 type Route struct {
@@ -125,11 +125,8 @@ func AddCustomRoute(route Route, routeACLAnn string, api api.HAProxyClient) (rel
 			return
 		}
 	}
-	if acl := CustomRoutes[route.BackendName]; acl != routeCond {
-		CustomRoutes[route.BackendName] = routeCond
-		reload = true
-		logger.Debugf("Custom Route to backend '%s' added, reload required", route.BackendName)
-	}
+
+	CustomRoutes = append(CustomRoutes, routeCond)
 	return reload, err
 }
 
@@ -147,5 +144,6 @@ func CustomRoutesReset(api api.HAProxyClient) (err error) {
 			return fmt.Errorf("unable to create main backendSwitching rule !!: %w", err)
 		}
 	}
+	CustomRoutes = make([]string, 0)
 	return
 }


### PR DESCRIPTION
Fixes #567

All custom routes are stored in the `routes.CustomRoutes` map using the backend name as the key (`ServiceNS_ServiceName_PortName`). When we encounter two distinct IngressRules, whether they are within the same Ingress or not, and they utilize different hosts or paths while pointing to the same Service, they end up sharing the same key in `CustomRoutes`. This similarity in keys results in comparison failures during every synchronization, requiring a hard reload of HAProxy.

Rather than storing the custom routes in a map keyed by backend name, this PR stores all the resulting `use_backend` directives in a slice and compares them between syncs.

