### PR TITLE
BUG/MINOR: prevents port conflicts on startup when using hostNetwork

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -44,7 +44,7 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/*cfg') }}
           restore-keys: |
             ${{ runner.os }}-go-
       - name: tidy
@@ -66,7 +66,7 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/*cfg') }}
           restore-keys: |
             ${{ runner.os }}-go-
       - name: tidy
@@ -89,7 +89,7 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/*cfg') }}
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Lint
@@ -111,7 +111,7 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/*cfg') }}
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Get dependencies
@@ -138,7 +138,7 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/*cfg') }}
         restore-keys: |
           ${{ runner.os }}-go-
     - uses: engineerd/setup-kind@v0.5.0

--- a/deploy/tests/tnr/routeacl/suite_test.go
+++ b/deploy/tests/tnr/routeacl/suite_test.go
@@ -62,7 +62,6 @@ func (suite *UseBackendSuite) BeforeTest(suiteName, testName string) {
 	suite.T().Logf("temporary configuration dir %s", suite.test.TempDir)
 }
 
-//nolint:dupword
 var haproxyConfig = `global
 daemon
 master-worker
@@ -75,25 +74,21 @@ peers localinstance
 
 frontend https
 mode http
-bind 127.0.0.1:8080 name v4
 http-request set-var(txn.base) base
 use_backend %[var(txn.path_match),field(1,.)]
 
 frontend http
 mode http
-bind 127.0.0.1:4443 name v4
 http-request set-var(txn.base) base
 use_backend %[var(txn.path_match),field(1,.)]
 
 frontend healthz
-bind 127.0.0.1:1042 name v4
 mode http
 monitor-uri /healthz
 option dontlog-normal
 
 frontend stats
   mode http
-  bind *:1024 name stats
   stats enable
   stats uri /
   stats refresh 10s

--- a/fs/usr/local/etc/haproxy/haproxy.cfg
+++ b/fs/usr/local/etc/haproxy/haproxy.cfg
@@ -27,25 +27,21 @@ peers localinstance
 
 frontend https
   mode http
-  bind 127.0.0.1:8080 name v4
   http-request set-var(txn.base) base
   use_backend %[var(txn.path_match),field(1,.)]
 
 frontend http
   mode http
-  bind 127.0.0.1:4443 name v4
   http-request set-var(txn.base) base
   use_backend %[var(txn.path_match),field(1,.)]
 
 frontend healthz
-  bind 127.0.0.1:1042 name v4
   mode http
   monitor-uri /healthz
   option dontlog-normal
 
 frontend stats
    mode http
-   bind *:1024 name stats
    http-request set-var(txn.base) base
    http-request use-service prometheus-exporter if { path /metrics }
    stats enable

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -195,7 +195,7 @@ func (c *HAProxyController) updateHAProxy() {
 func (c *HAProxyController) setToReady() {
 	healthzPort := c.osArgs.HealthzBindPort
 	logger.Panic(c.clientAPIClosure(func() error {
-		return c.haproxy.FrontendBindEdit("healthz",
+		return c.haproxy.FrontendBindCreate("healthz",
 			models.Bind{
 				BindParams: models.BindParams{
 					Name: "v4",
@@ -228,7 +228,7 @@ func (c *HAProxyController) setToReady() {
 	}))
 
 	logger.Panic(c.clientAPIClosure(func() error {
-		return c.haproxy.FrontendBindEdit("stats",
+		return c.haproxy.FrontendBindCreate("stats",
 			models.Bind{
 				BindParams: models.BindParams{
 					Name: "stats",


### PR DESCRIPTION
Creates new binds (instead of editing them) of the healthz and stats frontends to avoid port conflicts at the first start of the HAProxy when using hostNetwork: true.

Since these bind directives are not required, the first start of HAProxy is not affected.