### PR TITLE
enable TCPRoute to use HAProxy v2 protocol to communicate with the backend

### DIFF
--- a/documentation/doc.yaml
+++ b/documentation/doc.yaml
@@ -1878,3 +1878,17 @@ annotations:
     version_min: "1.7"
     example:
       - "tls-alpn: http/1.1"
+  - title: send-proxy-v2
+    type: string
+    group: gateway
+    dependencies: ""
+    default: "false"
+    description:
+      - For TCPRoutes only send HAProxy v2 protocol to the backend.
+    values:
+      - anything not 'True' or 'true' will be considered false
+    applies_to:
+      - gateway
+    version_min: "1.10"
+    example:
+      - "send-proxy-v2: 'true'"

--- a/pkg/store/types.go
+++ b/pkg/store/types.go
@@ -240,7 +240,9 @@ type BackendRef struct {
 	Group     *string
 	Kind      *string
 	Name      string
+	ProxyV2   bool
 }
+
 type LabelSelector struct {
 	MatchLabels      map[string]string
 	MatchExpressions []LabelSelectorRequirement


### PR DESCRIPTION
# For gateway API (≥ v0.5.1) #

## New annotation in TCPRoute ##
```yaml
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: TCPRoute
metadata:
  annotations:
    haproxy.org/send-proxy-v2: 'true'
```
this will enable to use HAProxy v2 protocol to communicate with the backend this is useful for transmitting the original IP of the remote client.  