### PR TITLE
BUG/MINOR: prevents unconditional restarts when prometheus is enabled

### DIFF
--- a/pkg/handler/prometheus.go
+++ b/pkg/handler/prometheus.go
@@ -17,7 +17,7 @@ type PrometheusEndpoint struct {
 
 //nolint:golint, stylecheck
 const (
-	PROMETHEUS_BACKEND_NAME = "haproxy-controller_prometheus_http"
+	PROMETHEUS_BACKEND_NAME = "haproxy-ingress_prometheus_http"
 	PROMETHEUS_URL_PATH     = "/metrics"
 )
 


### PR DESCRIPTION
When the `--prometheus` flag is passed, the prometheus backend check always fails because its name is incorrect in the code. So, all events received by the controller trigger a hard restart of HAProxy.