### PR TITLE
BUG/MINOR: prevents unconditional reloads when prometheus is enabled and controller namespace isn't `haproxy-controller`

### DIFF
--- a/pkg/handler/prometheus.go
+++ b/pkg/handler/prometheus.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/haproxytech/kubernetes-ingress/pkg/annotations"
@@ -17,8 +18,7 @@ type PrometheusEndpoint struct {
 
 //nolint:golint, stylecheck
 const (
-	PROMETHEUS_BACKEND_NAME = "haproxy-controller_prometheus_http"
-	PROMETHEUS_URL_PATH     = "/metrics"
+	PROMETHEUS_URL_PATH = "/metrics"
 )
 
 func (handler PrometheusEndpoint) Update(k store.K8s, h haproxy.HAProxy, a annotations.Annotations) (err error) {
@@ -26,9 +26,12 @@ func (handler PrometheusEndpoint) Update(k store.K8s, h haproxy.HAProxy, a annot
 		return
 	}
 
+	prometheusSvcName := "prometheus"
+	prometheusBackendName := fmt.Sprintf("%s_%s_http", handler.PodNs, prometheusSvcName)
+
 	status := store.EMPTY
 	var secret *store.Secret
-	_, errBackend := h.BackendGet(PROMETHEUS_BACKEND_NAME)
+	_, errBackend := h.BackendGet(prometheusBackendName)
 	backendExists := errBackend == nil
 
 	annSecret := annotations.String("prometheus-endpoint-auth-secret", k.ConfigMaps.Main.Annotations)
@@ -59,7 +62,6 @@ func (handler PrometheusEndpoint) Update(k store.K8s, h haproxy.HAProxy, a annot
 		return
 	}
 
-	prometheusSvcName := "prometheus"
 	svc := &store.Service{
 		Namespace:   handler.PodNs,
 		Name:        prometheusSvcName,


### PR DESCRIPTION
When the `--prometheus` flag is passed, the Prometheus backend check always fails if the controller namespace isn't `haproxy-controller`. Consequently, all events received by the controller trigger a reload of HAProxy.

```text
2024/03/09 12:32:14 INFO    instance/configuration.go:21 [transactionID=8a5a139f-1b65-4faf-8e40-dc467a54dcfb] reload required : creation/modification of prometheus endpoint
```

Since the backend name depends on the namespace, it shouldn't be hardcoded.