### PR TITLE
BUG/MINOR: prevents unnecessary reloads due to CRD defaults.name

### DIFF
--- a/pkg/controller/global.go
+++ b/pkg/controller/global.go
@@ -141,6 +141,7 @@ func (c *HAProxyController) defaultsCfg() {
 	}
 	env.SetDefaults(newDefaults)
 	newDefaults.ErrorFiles = defaults.ErrorFiles
+	newDefaults.Name = constants.DefaultsSectionName
 	diff := newDefaults.Diff(*defaults)
 	if len(diff) != 0 {
 		if err = c.haproxy.DefaultsPushConfiguration(*newDefaults); err != nil {


### PR DESCRIPTION
Every check on Defaults CRD triggers a reload because `default` section name is hardcoded as `haproxytech`: https://github.com/haproxytech/kubernetes-ingress/blob/13fc60b9a52d746bbf7a05afd1ebde580739223b/pkg/haproxy/api/global.go#L33

Since the default section name is hardcoded as `haproxytech`, every event processed by the controller will trigger a hard reload, regardless of the `spec.name` value the user passes in the Defaults CRD (even if blank), because the comparison check will never pass (unless the user sets `spec.name` exactly to `haproxytech`).
