### PR TITLE
Update doc.yaml - https-bind-port and ssl-redirect-port fixes

### DIFF
--- a/documentation/annotations.md
+++ b/documentation/annotations.md
@@ -867,7 +867,7 @@ Example:
 
 ```yaml
 ssl-redirect: "true"
-ssl-redirect-port: 8443
+ssl-redirect-port: "8443"
 ```
 
 ##### `tls-alpn`

--- a/documentation/controller.md
+++ b/documentation/controller.md
@@ -504,7 +504,7 @@ Possible values:
 Example:
 
 ```yaml
---http-bind-port=8443
+--https-bind-port=8443
 ```
 
 <p align='right'><a href='#haproxy-kubernetes-ingress-controller'>:arrow_up_small: back to top</a></p>

--- a/documentation/doc.yaml
+++ b/documentation/doc.yaml
@@ -254,10 +254,10 @@ image_arguments:
       - "A valid port in the range. Default: 8443"
     default: 8443
     version_min: "1.5"
-    example: --http-bind-port=8443
+    example: --https-bind-port=8443
     helm: |-
       helm install haproxy haproxytech/kubernetes-ingress \
-        --set-string "controller.extraArgs={--http-bind-port=8443}"
+        --set-string "controller.extraArgs={--https-bind-port=8443}"
   - argument: --disable-http
     description: Disabling the HTTP frontend.
     values:
@@ -1653,7 +1653,7 @@ annotations:
     version_min: "1.5"
     example:
       - 'ssl-redirect: "true"'
-      - "ssl-redirect-port: 8443"
+      - 'ssl-redirect-port: "8443"'
   - title: syslog-server
     type: "[syslog](#syslog-fields)"
     group: logging


### PR DESCRIPTION
ssl-redirect-port - in config map data everything is a stringso the number must be enclosed in quotes to be interpreted as string https-bind-port - the example was refererring to http-bind-port. probably copy-paste and forgot to update the name