### PR TITLE
Prevents improper overriding of `DefaultServer` when processing the `proto` annotation

### DIFF
--- a/pkg/annotations/service/proto.go
+++ b/pkg/annotations/service/proto.go
@@ -25,7 +25,7 @@ func (a *Proto) GetName() string {
 func (a *Proto) Process(k store.K8s, annotations ...map[string]string) error {
 	input := common.GetValue(a.GetName(), annotations...)
 	if input == "h2" {
-		if a.backend.DefaultServer != nil {
+		if a.backend.DefaultServer == nil {
 			a.backend.DefaultServer = &models.DefaultServer{}
 		}
 		a.backend.DefaultServer.Proto = "h2"


### PR DESCRIPTION
When the `proto: h2` annotation is used, an incorrect inequality check overrides the `DefaultServer`, clearing all configurations previously set by other annotations.

This PR fixes #648.