### PR TITLE
MINOR: fix info message when global config is updated

### DIFF
--- a/pkg/controller/global.go
+++ b/pkg/controller/global.go
@@ -47,7 +47,6 @@ func (c *HAProxyController) globalCfg() {
 	var newGlobal, global *models.Global
 	var newLg models.LogTargets
 	var err error
-	var updated []string
 	global, err = c.haproxy.GlobalGetConfiguration()
 	if err != nil {
 		logger.Error(err)
@@ -91,13 +90,12 @@ func (c *HAProxyController) globalCfg() {
 	diff := newGlobal.Diff(*global)
 	if len(diff) != 0 {
 		logger.Error(c.haproxy.GlobalPushConfiguration(*newGlobal))
-		instance.Restart("Global config updated: %s", strings.Join(updated, "\n"))
+		instance.Restart("Global config updated: %v", diff)
 	}
 	diff = newLg.Diff(lg)
-	// updated = deep.Equal(newLg, lg)
 	if len(diff) != 0 {
 		logger.Error(c.haproxy.GlobalPushLogTargets(newLg))
-		instance.Restart("Global log targets updated: %s", strings.Join(updated, "\n"))
+		instance.Restart("Global log targets updated: %v", diff)
 	}
 	c.globalCfgSnipp()
 }

--- a/pkg/controller/global.go
+++ b/pkg/controller/global.go
@@ -90,12 +90,12 @@ func (c *HAProxyController) globalCfg() {
 	diff := newGlobal.Diff(*global)
 	if len(diff) != 0 {
 		logger.Error(c.haproxy.GlobalPushConfiguration(*newGlobal))
-		instance.Restart("Global config updated: %v", diff)
+		instance.Restart("Global config updated: %+v", diff)
 	}
 	diff = newLg.Diff(lg)
 	if len(diff) != 0 {
 		logger.Error(c.haproxy.GlobalPushLogTargets(newLg))
-		instance.Restart("Global log targets updated: %v", diff)
+		instance.Restart("Global log targets updated: %+v", diff)
 	}
 	c.globalCfgSnipp()
 }
@@ -146,7 +146,7 @@ func (c *HAProxyController) defaultsCfg() {
 			logger.Error(err)
 			return
 		}
-		instance.Reload("Defaults config updated: %v", diff)
+		instance.Reload("Defaults config updated: %+v", diff)
 	}
 }
 


### PR DESCRIPTION
This pull request is refering to https://github.com/haproxytech/kubernetes-ingress/issues/652

**CAREFUL**
I am absolutely not familiar with Go language (I'm a PHP guy). I tried to be very careful but please read my code carefully before accepting the commit.

**EXPLANATIONS**
I removed the unused `updated` variable and fixed the error message. I just used the same syntax as line 149.
I also used `%+v` to show field name (more explicit).