### PR TITLE
BUILD/MINOR: ci: upgrade github actions

### DIFF
--- a/.github/workflows/.goreleaser.yml
+++ b/.github/workflows/.goreleaser.yml
@@ -2,20 +2,20 @@ name: goreleaser
 on:
   push:
     tags:
-      - '*'
+      - "*"
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # we have to fetch all history to be able to generate the release note. c.f. https://goreleaser.com/ci/actions/.
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
           check-latest: true
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set the expected Go version
         run: |
           GOMOD_VERSION=$(cat go.mod | grep -i "^go " | sed -e "s/go //g")
           echo "GOMOD_VERSION=${GOMOD_VERSION}" >> $GITHUB_ENV
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
           check-latest: true
       - name: generating documentation
         run: cd documentation/gen && go run .
@@ -35,13 +35,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
           check-latest: true
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build
@@ -58,13 +58,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
           check-latest: true
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build
@@ -82,13 +82,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
           check-latest: true
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build
@@ -104,58 +104,58 @@ jobs:
     runs-on: ubuntu-latest
     needs: ["lint"]
     steps:
-    - name: Check out code
-      uses: actions/checkout@v3
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version-file: 'go.mod'
-        check-latest: true
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-    - name: Build
-      run: |
-        go build -v .
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          check-latest: true
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
+      - name: Build
+        run: |
+          go build -v .
   e2e:
     strategy:
-        matrix:
-          k8s-version: ['v1.30.0']
+      matrix:
+        k8s-version: ["v1.30.0"]
     needs: ["build"]
     runs-on: ubuntu-latest
     steps:
-    - name: Check out code
-      uses: actions/checkout@v3
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version-file: 'go.mod'
-        check-latest: true
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - uses: engineerd/setup-kind@v0.5.0
-      with:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          check-latest: true
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - uses: engineerd/setup-kind@v0.5.0
+        with:
           name: dev
           config: deploy/tests/kind-config.yaml
           image: kindest/node:${{ matrix.k8s-version }}
           version: v0.23.0
-    - name: Setup
-      run: CI_ENV=github deploy/tests/create.sh
-    - name: Run parallel e2e tests
-      run: go test ./... -v --tags=e2e_parallel  --tags=e2e_https
-    - name: Run sequential e2e tests
-      run: go test ./... -v -p 1 --tags=e2e_sequential
+      - name: Setup
+        run: CI_ENV=github deploy/tests/create.sh
+      - name: Run parallel e2e tests
+        run: go test ./... -v --tags=e2e_parallel  --tags=e2e_https
+      - name: Run sequential e2e tests
+        run: go test ./... -v -p 1 --tags=e2e_sequential

--- a/.github/workflows/docker_auto_release.yml
+++ b/.github/workflows/docker_auto_release.yml
@@ -37,7 +37,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -46,7 +46,7 @@ jobs:
 
       - name: Check out repo
         id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docker_description.yml
+++ b/.github/workflows/docker_description.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Check out repo
         id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Update Docker Hub description
         id: description

--- a/.github/workflows/docker_manual_release.yml
+++ b/.github/workflows/docker_manual_release.yml
@@ -35,7 +35,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -44,7 +44,7 @@ jobs:
 
       - name: Check out repo
         id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docker_nightly.yml
+++ b/.github/workflows/docker_nightly.yml
@@ -39,7 +39,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -48,7 +48,7 @@ jobs:
 
       - name: Check out repo
         id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
This pull request updates the GitHub Actions to their latest versions, addressing existing warnings.

- Upgrade `actions/checkout` to v4
- Upgrade `actions/setup-go` to v5
- Upgrade `actions/cache` to v4
