### PR TITLE
BUG: update IC pod-serving port to match default

### DIFF
--- a/deploy/haproxy-ingress-daemonset.yaml
+++ b/deploy/haproxy-ingress-daemonset.yaml
@@ -175,11 +175,11 @@ spec:
             port: 1042
         ports:
         - name: http
-          containerPort: 80
-          hostPort: 80
+          containerPort: 8080
+          hostPort: 8080
         - name: https
-          containerPort: 443
-          hostPort: 443
+          containerPort: 8443
+          hostPort: 8443
         - name: stat
           containerPort: 1024
           hostPort: 1024

--- a/deploy/haproxy-ingress.yaml
+++ b/deploy/haproxy-ingress.yaml
@@ -176,9 +176,9 @@ spec:
             port: 1042
         ports:
         - name: http
-          containerPort: 80
+          containerPort: 8080
         - name: https
-          containerPort: 443
+          containerPort: 8443
         - name: stat
           containerPort: 1024
         env:


### PR DESCRIPTION
mismatched from service object

Hey all - noticed when updating our deployment that nothing is being served on either port 443 or port 80 on the pod anymore. Figured I'd correct this to the current defaults.

Thanks!