### PR TITLE
supporting thread pin on http https and healthz frontend

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -225,7 +225,8 @@ func (c *HAProxyController) setToReady() {
 		return c.haproxy.FrontendBindCreate("healthz",
 			models.Bind{
 				BindParams: models.BindParams{
-					Name: "v4",
+					Name:   "v4",
+					Thread: c.osArgs.HealthzBindThread,
 				},
 				Address: fmt.Sprintf("0.0.0.0:%d", healthzPort),
 			})
@@ -235,8 +236,9 @@ func (c *HAProxyController) setToReady() {
 			return c.haproxy.FrontendBindCreate("healthz",
 				models.Bind{
 					BindParams: models.BindParams{
-						Name: "v6",
-						V4v6: true,
+						Name:   "v6",
+						V4v6:   true,
+						Thread: c.osArgs.HealthzBindThread,
 					},
 					Address: fmt.Sprintf(":::%d", healthzPort),
 				})

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -96,14 +96,16 @@ func (c *HAProxyController) startupHandlers() error {
 	handlers := []UpdateHandler{
 		handler.GlobalCfg{},
 		handler.HTTPBind{
-			HTTP:      !c.osArgs.DisableHTTP,
-			HTTPS:     !c.osArgs.DisableHTTPS,
-			IPv4:      !c.osArgs.DisableIPV4,
-			IPv6:      !c.osArgs.DisableIPV6,
-			HTTPPort:  c.osArgs.HTTPBindPort,
-			HTTPSPort: c.osArgs.HTTPSBindPort,
-			IPv4Addr:  c.osArgs.IPV4BindAddr,
-			IPv6Addr:  c.osArgs.IPV6BindAddr,
+			HTTP:            !c.osArgs.DisableHTTP,
+			HTTPS:           !c.osArgs.DisableHTTPS,
+			IPv4:            !c.osArgs.DisableIPV4,
+			IPv6:            !c.osArgs.DisableIPV6,
+			HTTPPort:        c.osArgs.HTTPBindPort,
+			HTTPSPort:       c.osArgs.HTTPSBindPort,
+			IPv4Addr:        c.osArgs.IPV4BindAddr,
+			IPv6Addr:        c.osArgs.IPV6BindAddr,
+			HTTPBindThread:  c.osArgs.HTTPBindThread,
+			HTTPSBindThread: c.osArgs.HTTPSBindThread,
 		},
 	}
 

--- a/pkg/utils/flags.go
+++ b/pkg/utils/flags.go
@@ -92,9 +92,12 @@ type OSArgs struct {
 	ControllerPort             int            `long:"controller-port" description:"port to listen on for controller data: prometheus, pprof" default:"6060"`
 	HTTPBindPort               int64          `long:"http-bind-port" default:"8080" description:"port to listen on for HTTP traffic"`
 	HTTPSBindPort              int64          `long:"https-bind-port" default:"8443" description:"port to listen on for HTTPS traffic"`
+	HTTPBindThread             string         `long:"http-bind-thread" description:"default http service bind thread params eg: 1-1" default:""`
+	HTTPSBindThread            string         `long:"https-bind-thread" description:"default https service bind thread params eg: 1-1" default:""`
 	SyncPeriod                 time.Duration  `long:"sync-period" default:"5s" description:"Sets the period at which the controller syncs HAProxy configuration file"`
 	CacheResyncPeriod          time.Duration  `long:"cache-resync-period" default:"10m" description:"Sets the underlying Shared Informer resync period: resyncing controller with informers cache"`
 	HealthzBindPort            int64          `long:"healthz-bind-port" default:"1042" description:"port to listen on for probes"`
+	HealthzBindThread          string         `long:"healthz-bind-thread" description:"default healthz service bind thread params eg: 1-1" default:""`
 	LogLevel                   LogLevelValue  `long:"log" default:"info" description:"level of log messages you can see"`
 	DisableIPV4                bool           `long:"disable-ipv4" description:"toggle to disable the IPv4 protocol from all frontends"`
 	External                   bool           `short:"e" long:"external" description:"use as external Ingress Controller (out of k8s cluster)"`


### PR DESCRIPTION
We are currently using ingress controller as external mode, so it would be nice that we can control the thread pin on http/https/healthz for better performance.

The PR is adding those flag to support thread pin for ingress controller to set them on haproxy config.

i don't think its a necessary requirement in term of if the controller is running inside Kubernetes cluster, but it would be a great feature to provide for people running it as external mode.