### PR TITLE
MINOR: Refine route-acl rules to prevent unintended prefix matches

### DIFF
--- a/.aspell.yml
+++ b/.aspell.yml
@@ -1,6 +1,7 @@
 mode: commit
 min_length: 3
 allowed:
+  - acl
   - aspell
   - repo
   - yaml

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -108,17 +108,9 @@ func AddCustomRoute(route Route, routeACLAnn string, api api.HAProxyClient) (err
 	}
 	if route.Path.Path != "" {
 		if route.Path.PathTypeMatch == store.PATH_TYPE_EXACT {
-			if routeCond == "" {
-				routeCond = fmt.Sprintf("{ path %s }", route.Path.Path)
-			} else {
-				routeCond = fmt.Sprintf("%s { path %s }", routeCond, route.Path.Path)
-			}
+			routeCond = fmt.Sprintf("%s{ path %s }", routeCond, route.Path.Path)
 		} else {
-			if routeCond == "" {
-				routeCond = fmt.Sprintf("{ path -m beg %s }", route.Path.Path)
-			} else {
-				routeCond = fmt.Sprintf("%s { path -m beg %s }", routeCond, route.Path.Path)
-			}
+			routeCond = fmt.Sprintf("%s{ path -m beg %s }", routeCond, route.Path.Path)
 		}
 	}
 	routeCond = fmt.Sprintf("%s { %s } ", routeCond, routeACLAnn)

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -110,7 +110,12 @@ func AddCustomRoute(route Route, routeACLAnn string, api api.HAProxyClient) (err
 		if route.Path.PathTypeMatch == store.PATH_TYPE_EXACT {
 			routeCond = fmt.Sprintf("%s{ path %s }", routeCond, route.Path.Path)
 		} else {
-			routeCond = fmt.Sprintf("%s{ path -m beg %s }", routeCond, route.Path.Path)
+			if route.Path.Path == "/" {
+				routeCond = fmt.Sprintf("%s{ path -m beg %s }", routeCond, route.Path.Path)
+			} else {
+				path := strings.TrimSuffix(route.Path.Path, "/")
+				routeCond = fmt.Sprintf("%s{ path -m reg ^%s($|/) }", routeCond, path)
+			}
 		}
 	}
 	routeCond = fmt.Sprintf("%s { %s } ", routeCond, routeACLAnn)


### PR DESCRIPTION
Since `route-acl` annotated rules take precedence over others, this PR updates its behavior to ensure they do not unintentionally overwrite other rules that share the same word prefix.

For example, a rule matching the path prefix `/api` should not inadvertently handle requests to `/apiary`.

To address this, the rule `{ path -m beg /api }` has been replaced with a alternative that validates the URL's termination, ensuring it matches only `/api$` or `/api/.*`:

```
# before this PR:
use_backend app_api_http if { var(txn.host) -m str api.demo } { path -m beg /api } { ... }

# after:
use_backend app_api_http if { var(txn.host) -m str api.demo } { path -m reg ^/api($|/) } { ... }
```

For better maintainability, this PR also refactors the `AddCustomRoute` function to eliminate redundancy introduced in commit c28d620aee948a8e912c9a52b4be4ad4d8cd6c82. The updated code removes repetition without add extra spaces.


