### PR TITLE
BUG: Make ingress pathType "Exact" always override pathType "Prefix"

### DIFF
--- a/deploy/tests/e2e/client.go
+++ b/deploy/tests/e2e/client.go
@@ -202,7 +202,7 @@ func runtimeCommand(command string) (result []byte, err error) {
 	if err != nil {
 		return
 	}
-	result = make([]byte, 1024)
+	result = make([]byte, 2048)
 	_, err = conn.Read(result)
 	conn.Close()
 	return
@@ -217,7 +217,7 @@ func GetHAProxyMapCount(mapName string) (count int, err error) {
 	scanner := bufio.NewScanner(bytes.NewReader(result))
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.Contains(line, mapName) {
+		if strings.Contains(line, mapName+".map") {
 			r := regexp.MustCompile("entry_cnt=[0-9]*")
 			match := r.FindString(line)
 			nbr := strings.Split(match, "=")[1]

--- a/deploy/tests/e2e/map-updates/update_test.go
+++ b/deploy/tests/e2e/map-updates/update_test.go
@@ -30,17 +30,27 @@ func (suite *MapUpdateSuite) Test_Update() {
 			suite.tmplData.Paths = append(suite.tmplData.Paths, strconv.Itoa(i))
 		}
 		oldInfo, err := e2e.GetGlobalHAProxyInfo()
-		oldCount, err := e2e.GetHAProxyMapCount("path-prefix")
+		oldCountExact, err := e2e.GetHAProxyMapCount("path-exact")
+		suite.Require().NoError(err)
+		oldCountPrefixExact, err := e2e.GetHAProxyMapCount("path-prefix-exact")
+		suite.Require().NoError(err)
+		oldCountPrefix, err := e2e.GetHAProxyMapCount("path-prefix")
 		suite.Require().NoError(err)
 		suite.Require().NoError(suite.test.Apply("config/ingress.yaml.tmpl", suite.test.GetNS(), suite.tmplData))
 		suite.Require().Eventually(func() bool {
 			newInfo, err := e2e.GetGlobalHAProxyInfo()
 			suite.Require().NoError(err)
-			count, err := e2e.GetHAProxyMapCount("path-prefix")
+			countExact, err := e2e.GetHAProxyMapCount("path-exact")
 			suite.Require().NoError(err)
-			numOfAddedEntries := count - oldCount + 1 // We add one because there's already an entry at the begining which will be removed
-			suite.T().Logf("oldInfo.Pid(%s) == newInfo.Pid(%s) && additional path-prefix.count(%d) == %d", oldInfo.Pid, newInfo.Pid, numOfAddedEntries, n)
-			return oldInfo.Pid == newInfo.Pid && numOfAddedEntries == n
+			countPrefixExact, err := e2e.GetHAProxyMapCount("path-prefix-exact")
+			suite.Require().NoError(err)
+			countPrefix, err := e2e.GetHAProxyMapCount("path-prefix")
+			suite.Require().NoError(err)
+			numOfAddedEntriesExact := countExact - oldCountExact
+			numOfAddedEntriesPrefixExact := countPrefixExact - oldCountPrefixExact
+			numOfAddedEntriesPrefix := countPrefix - oldCountPrefix + 1 // We add one because there's already an entry at the beginning which will be removed
+			suite.T().Logf("oldInfo.Pid(%s) == newInfo.Pid(%s) && additional path-exact.count(%d) == %d && additional path-prefix-exact.count(%d) == %d && additional path-prefix.count(%d) == %d", oldInfo.Pid, newInfo.Pid, numOfAddedEntriesExact, 0, numOfAddedEntriesPrefixExact, n, numOfAddedEntriesPrefix, n)
+			return oldInfo.Pid == newInfo.Pid && numOfAddedEntriesExact == 0 && numOfAddedEntriesPrefixExact == n && numOfAddedEntriesPrefix == n
 		}, e2e.WaitDuration, e2e.TickDuration)
 	})
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -301,6 +301,12 @@ func (c *HAProxyController) setupHAProxyRules() error {
 			c.haproxy.AddRule(frontend, rules.ReqSetVar{
 				Name:       "path_match",
 				Scope:      "txn",
+				Expression: fmt.Sprintf("var(txn.host_match),concat(,txn.path,),map(%s)", maps.GetPath(route.PATH_PREFIX_EXACT)),
+				CondTest:   "!{ var(txn.path_match) -m found }",
+			}, false),
+			c.haproxy.AddRule(frontend, rules.ReqSetVar{
+				Name:       "path_match",
+				Scope:      "txn",
 				Expression: fmt.Sprintf("var(txn.host_match),concat(,txn.path,),map_beg(%s)", maps.GetPath(route.PATH_PREFIX)),
 				CondTest:   "!{ var(txn.path_match) -m found }",
 			}, false),

--- a/pkg/haproxy/main.go
+++ b/pkg/haproxy/main.go
@@ -53,6 +53,7 @@ func New(osArgs utils.OSArgs, env env.Env, cfgFile []byte, p process.Process, cl
 		route.SNI,
 		route.HOST,
 		route.PATH_EXACT,
+		route.PATH_PREFIX_EXACT,
 		route.PATH_PREFIX,
 	}
 	if h.Maps, err = maps.New(env.MapsDir, persistentMaps); err != nil {

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -33,10 +33,11 @@ const (
 	FrontendHTTP  = "http"
 	FrontendHTTPS = "https"
 	// Routing Maps
-	SNI         maps.Name = "sni"
-	HOST        maps.Name = "host"
-	PATH_EXACT  maps.Name = "path-exact"
-	PATH_PREFIX maps.Name = "path-prefix"
+	SNI               maps.Name = "sni"
+	HOST              maps.Name = "host"
+	PATH_EXACT        maps.Name = "path-exact"
+	PATH_PREFIX_EXACT maps.Name = "path-prefix-exact"
+	PATH_PREFIX       maps.Name = "path-prefix"
 )
 
 var (
@@ -87,11 +88,11 @@ func AddHostPathRoute(route Route, mapFiles maps.Maps) error {
 		mapFiles.MapAppend(PATH_PREFIX, route.Host+"/"+"\t\t\t"+value)
 	case route.Path.PathTypeMatch == store.PATH_TYPE_PREFIX:
 		path = strings.TrimSuffix(path, "/")
-		mapFiles.MapAppend(PATH_EXACT, route.Host+path+"\t\t\t"+value)
+		mapFiles.MapAppend(PATH_PREFIX_EXACT, route.Host+path+"\t\t\t"+value)
 		mapFiles.MapAppend(PATH_PREFIX, route.Host+path+"/"+"\t\t\t"+value)
 	case route.Path.PathTypeMatch == store.PATH_TYPE_IMPLEMENTATION_SPECIFIC:
 		path = strings.TrimSuffix(path, "/")
-		mapFiles.MapAppend(PATH_EXACT, route.Host+path+"\t\t\t"+value)
+		mapFiles.MapAppend(PATH_PREFIX_EXACT, route.Host+path+"\t\t\t"+value)
 		mapFiles.MapAppend(PATH_PREFIX, route.Host+path+"\t\t\t"+value)
 	default:
 		return fmt.Errorf("unknown path type '%s' with backend '%s'", route.Path.PathTypeMatch, route.BackendName)


### PR DESCRIPTION
Fixes #703.

We introduce a new map `path-prefix-exact` which contains exact match patterns for ingress pathType `Prefix`. From now on the map `path-exact` will only contain patterns from pathType `Exact`. The generated HAProxy config will check `path-exact` first,  `path-prefix-exact` second and `path-prefix` third. That way pathType `Exact` always wins.