### PR TITLE
BUG: Fix healthcheck port for kubectl deployments

### DIFF
--- a/deploy/haproxy-ingress-daemonset.yaml
+++ b/deploy/haproxy-ingress-daemonset.yaml
@@ -172,7 +172,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 1042
+            port: 1024
         ports:
         - name: http
           containerPort: 8080

--- a/deploy/haproxy-ingress.yaml
+++ b/deploy/haproxy-ingress.yaml
@@ -173,7 +173,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 1042
+            port: 1024
         ports:
         - name: http
           containerPort: 8080


### PR DESCRIPTION
Changed livenessProbe port from `1042` to `1024` for kubectl deployments.

The pod did not listen on port `1042`, so connection for healthcheck was refused and the check failed. Changing it to the stats port `1024` fixes the health check.