### PR TITLE
MEDIUM: config: add disable-ingress-status-update configuration flag

### DIFF
--- a/documentation/controller.md
+++ b/documentation/controller.md
@@ -1,3 +1,4 @@
+
 # ![HAProxy](../assets/images/haproxy-weblogo-210x49.png "HAProxy")
 
 ## HAProxy kubernetes ingress controller

--- a/documentation/controller.md
+++ b/documentation/controller.md
@@ -1,4 +1,3 @@
-
 # ![HAProxy](../assets/images/haproxy-weblogo-210x49.png "HAProxy")
 
 ## HAProxy kubernetes ingress controller
@@ -49,6 +48,7 @@ Image can be run with arguments:
 | [`--disable-writing-only-if-reload`](#--disable-writing-only-if-reload) :construction:(dev) | `false` |
 | [`--input-file`](#--input-file) :construction:(dev) |  |
 | [`--output-file`](#--output-file) :construction:(dev) |  |
+| [`--disable-ingress-status-update`](#--disable-ingress-status-update) | `false` |
 
 
 ### `--configmap`
@@ -879,6 +879,22 @@ Example:
 
 ```yaml
 --output-file=/home/xxx/convert/v3/global-full.yaml
+```
+
+<p align='right'><a href='#haproxy-kubernetes-ingress-controller'>:arrow_up_small: back to top</a></p>
+
+### `--disable-ingress-status-update`
+
+  If set, disables updating the status field of Ingress resources by the controller. By default, the controller will update the status field with the LoadBalancer address. This flag is useful if you want to prevent the controller from modifying Ingress status, for example when using another controller or external process to manage status updates.
+
+Possible values:
+
+- Boolean value, just need to declare the flag to disable status updates.
+
+Example:
+
+```yaml
+--disable-ingress-status-update
 ```
 
 <p align='right'><a href='#haproxy-kubernetes-ingress-controller'>:arrow_up_small: back to top</a></p>

--- a/documentation/doc.yaml
+++ b/documentation/doc.yaml
@@ -420,6 +420,16 @@ image_arguments:
         - Path a to a CRD manifest where the converted v3 CRDs will be written
     example: --output-file=/home/xxx/convert/v3/global-full.yaml
     version_min: "3.2"
+  - argument: --disable-ingress-status-update
+    description: |-
+      If set, disables updating the status field of Ingress resources by the controller.
+      By default, the controller will update the status field with the LoadBalancer address.
+      This flag is useful if you want to prevent the controller from modifying Ingress status, for example when using another controller or external process to manage status updates.
+    values:
+      - Boolean flag; just declare the flag to disable status updates.
+    default: false
+    version_min: "3.0"
+    example: --disable-ingress-status-update
 groups:
   config-snippet:
     header: |-

--- a/pkg/controller/builder.go
+++ b/pkg/controller/builder.go
@@ -176,7 +176,7 @@ func (builder *Builder) Build() *HAProxyController {
 	}
 	updateStatusManager := builder.updateStatusManager
 	if updateStatusManager == nil {
-		updateStatusManager = status.New(builder.clientSet, builder.osArgs.IngressClass, builder.osArgs.EmptyIngressClass)
+		updateStatusManager = status.New(builder.clientSet, builder.osArgs.IngressClass, builder.osArgs.EmptyIngressClass, builder.osArgs.DisableIngressStatusUpdate)
 	}
 	hostname, _ := os.Hostname()
 	podIP := utils.GetIP()

--- a/pkg/ingress/status.go
+++ b/pkg/ingress/status.go
@@ -11,7 +11,12 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func (i *Ingress) UpdateStatus(client *kubernetes.Clientset) (err error) {
+func (i *Ingress) UpdateStatus(client *kubernetes.Clientset, disableStatusUpdate bool) (err error) {
+	if disableStatusUpdate {
+		logger.Tracef("Skipping update of LoadBalancer status in ingress %s/%s due to configuration", i.resource.Namespace, i.resource.Name)
+		return nil
+	}
+
 	var lbi []networkingv1.IngressLoadBalancerIngress
 
 	for _, addr := range i.resource.Addresses {

--- a/pkg/status/updatestatus.go
+++ b/pkg/status/updatestatus.go
@@ -17,17 +17,19 @@ type UpdateStatusManager interface {
 }
 
 type UpdateStatusManagerImpl struct {
-	client            *kubernetes.Clientset
-	ingressClass      string
-	updateIngresses   []*ingress.Ingress
-	emptyIngressClass bool
+	client                     *kubernetes.Clientset
+	ingressClass               string
+	updateIngresses            []*ingress.Ingress
+	emptyIngressClass          bool
+	disableIngressStatusUpdate bool
 }
 
-func New(client *kubernetes.Clientset, ingressClass string, emptyIngressClass bool) UpdateStatusManager {
+func New(client *kubernetes.Clientset, ingressClass string, emptyIngressClass bool, disableIngressStatusUpdate bool) UpdateStatusManager {
 	return &UpdateStatusManagerImpl{
-		client:            client,
-		ingressClass:      ingressClass,
-		emptyIngressClass: emptyIngressClass,
+		client:                     client,
+		ingressClass:               ingressClass,
+		emptyIngressClass:          emptyIngressClass,
+		disableIngressStatusUpdate: disableIngressStatusUpdate,
 	}
 }
 
@@ -75,7 +77,7 @@ func (m *UpdateStatusManagerImpl) Update(k store.K8s, h haproxy.HAProxy, a annot
 		go func() {
 			for _, ing := range ingresses {
 				if ing != nil {
-					errs.Add(ing.UpdateStatus(m.client))
+					errs.Add(ing.UpdateStatus(m.client, m.disableIngressStatusUpdate))
 				}
 			}
 		}()

--- a/pkg/utils/flags.go
+++ b/pkg/utils/flags.go
@@ -122,4 +122,5 @@ type OSArgs struct {
 	DisableDelayedWritingOnlyIfReload bool           `long:"disable-writing-only-if-reload" description:"disable the delayed writing of files to disk only in case of haproxy reload (=write files to disk even if no reload)"`
 	CRDInputFile                      string         `long:"input-file" description:"The file path of a CRD manifest to convert"`
 	CRDOutputFile                     string         `long:"output-file" description:"The file path of the converted (to the most recent version) CRD manifest"`
+	DisableIngressStatusUpdate        bool           `long:"disable-ingress-status-update" description:"If true, disables updating the status field of Ingress resources"`
 }


### PR DESCRIPTION
This PR introduces a new controller configuration flag. When enabled, this flag prevents the controller from updating the status field of Ingress resources. By default, status updates remain enabled.

New flag:
```
--disable-ingress-status-update (boolean, default: false)
```

When set, the controller will skip updating the LoadBalancer status field in managed Ingress resources.
Useful for scenarios where another controller or external process manages Ingress status, or when status updates are not desired. It won't set status field and it will be just empty:

```
$ k get ingress test-ingress-99999 -o jsonpath='{.status}' | jq . -r
{
  "loadBalancer": {}
}
```

Code changes:

* Added the DisableIngressStatusUpdate field to the configuration struct.
* Passed the flag through the controller and status update logic.
* Updated the UpdateStatus method to respect the flag.
* Updated documentation

The flag is now listed in the arguments table and has a dedicated section describing its usage and example. If the flag is not specified, status updates are enabled by default.