### PR TITLE
BUG/MINOR: controller: Fix wildcard host matching with route-acl

### DIFF
--- a/.aspell.yml
+++ b/.aspell.yml
@@ -57,3 +57,5 @@ allowed:
   - frontent
   - pprof
   - preload
+  - hostname
+  - str

--- a/deploy/tests/tnr/routeacl/usebackend_test.go
+++ b/deploy/tests/tnr/routeacl/usebackend_test.go
@@ -32,3 +32,53 @@ func (suite *UseBackendSuite) TestUseBackend() {
 		suite.Exactly(c, 2, "use_backend for route-acl is repeated %d times but expected 2", c)
 	})
 }
+
+func (suite *UseBackendSuite) TestNonWildcardHostWithRouteACL() {
+	// Test non-wildcard host first to ensure route-acl works
+	suite.NonWildcardHostFixture()
+	suite.Run("Non-wildcard host should use string matching (-m str) with route-acl", func() {
+		contents, err := os.ReadFile(filepath.Join(suite.test.TempDir, "haproxy.cfg"))
+		if err != nil {
+			suite.T().Error(err.Error())
+		}
+
+		// Check that -m str is used with non-wildcard hosts in route-acl
+		if !strings.Contains(string(contents), "var(txn.host) -m str api.example.local") {
+			suite.T().Error("Expected to find 'var(txn.host) -m str api.example.local' in HAProxy config")
+		}
+
+		// Check that route-acl annotation is applied
+		if !strings.Contains(string(contents), "path_reg path-in-bug-repro$") {
+			suite.T().Error("Expected to find route-acl pattern 'path_reg path-in-bug-repro$' in HAProxy config")
+		}
+	})
+}
+
+func (suite *UseBackendSuite) TestWildcardHostWithRouteACL() {
+	// This test addresses https://github.com/haproxytech/kubernetes-ingress/issues/734
+	suite.WildcardHostFixture()
+	suite.Run("Wildcard host should use suffix matching (-m end) with route-acl", func() {
+		contents, err := os.ReadFile(filepath.Join(suite.test.TempDir, "haproxy.cfg"))
+		if err != nil {
+			suite.T().Error(err.Error())
+		}
+
+		// Debug: Print the actual config to see what's generated
+		suite.T().Logf("Generated HAProxy config:\n%s", string(contents))
+
+		// Check that -m end is used with wildcard hosts in route-acl
+		if !strings.Contains(string(contents), "var(txn.host) -m end .example.local") {
+			suite.T().Error("Expected to find 'var(txn.host) -m end .example.local' in HAProxy config")
+		}
+
+		// Check that the buggy -m str pattern is NOT used
+		if strings.Contains(string(contents), "var(txn.host) -m str *.example.local") {
+			suite.T().Error("Found buggy pattern 'var(txn.host) -m str *.example.local' in HAProxy config")
+		}
+
+		// Check that route-acl annotation is applied
+		if !strings.Contains(string(contents), "path_reg path-in-bug-repro$") {
+			suite.T().Error("Expected to find route-acl pattern 'path_reg path-in-bug-repro$' in HAProxy config")
+		}
+	})
+}

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -104,7 +104,13 @@ func AddHostPathRoute(route Route, mapFiles maps.Maps) error {
 func AddCustomRoute(route Route, routeACLAnn string, api api.HAProxyClient) (err error) {
 	var routeCond string
 	if route.Host != "" {
-		routeCond = fmt.Sprintf("{ var(txn.host) -m str %s } ", route.Host)
+		if route.Host[0] == '*' {
+			// Wildcard host - use suffix matching
+			routeCond = fmt.Sprintf("{ var(txn.host) -m end %s } ", route.Host[1:])
+		} else {
+			// Regular host - use string matching
+			routeCond = fmt.Sprintf("{ var(txn.host) -m str %s } ", route.Host)
+		}
 	}
 	if route.Path.Path != "" {
 		if route.Path.PathTypeMatch == store.PATH_TYPE_EXACT {


### PR DESCRIPTION
When an Ingress resource used a wildcard host (e.g., `*.example.com`) in combination with the `haproxy.org/route-acl` service annotation, the controller would generate an incorrect HAProxy ACL. It used an exact string match (`-m str`) on the literal value `*.example.com`, which would fail to match any intended subdomains.

This patch modifies the route generation logic to inspect the hostname. If the host begins with an asterisk ('*'), it now correctly generates an ACL using a suffix match (`-m end`) and removes the leading asterisk from the hostname string.

For non-wildcard hosts, the original behavior of using an exact string match (`-m str`) is preserved.

Fixes: #734