### PR TITLE
BUILD/MINOR: correct aspell configuration loading in CI pipeline

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -6,6 +6,8 @@ jobs:
     name: HAProxy check commit message
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code
+        uses: actions/checkout@v4
       - name: commit-policy
         uses: docker://ghcr.io/haproxytech/commit-check:5.2.0
         env:


### PR DESCRIPTION
The CI pipeline was experiencing intermittent failures due to aspell not correctly loading the local configuration files. This resulted in spelling checks being performed with default settings, leading to false positives and unpredictable behavior in the pipeline.

This patch addresses the issue by adding a step with @actions/checkout@v4 action, which loads the repository code to the CI pipeline, leading to the configurations being read in CI time