### PR TITLE
BUG/MINOR: fix unnecessary restarts when diffing LogTargets after change in client-native API

### DIFF
--- a/pkg/haproxy/api/global.go
+++ b/pkg/haproxy/api/global.go
@@ -95,8 +95,8 @@ func (c *clientNative) GlobalPushLogTargets(logTargets models.LogTargets) error 
 			break
 		}
 	}
-	for _, log := range logTargets {
-		err = configuration.CreateLogTarget(0, string(parser.Global), parser.GlobalSectionName, log, c.activeTransaction, 0)
+	for i, log := range logTargets {
+		err = configuration.CreateLogTarget(int64(i), string(parser.Global), parser.GlobalSectionName, log, c.activeTransaction, 0)
 		if err != nil {
 			return fmt.Errorf("unable to update HAProxy's global log targets: %w", err)
 		}


### PR DESCRIPTION
This issue was previously fixed in #451, where the `LogTarget.Index` field was being set to 0 for all entries, causing the old and new lists to never match. The fix was to use the loop index when creating LogTarget objects.

The change in `client-native`'s commit [58cdaf9](https://github.com/haproxytech/client-native/commit/58cdaf9011f5f15e6810b7607b7f64de315942e9#diff-d1d3315565e4a5f96e5cf85b85442069b6fbf3a0dd4bb0c17928389b9e5eee01) removed the `.Index` field from `LogTarget` and moved it to the `CreateLogTarget` method, but the current code passes 0 as the id parameter for all log targets, reversing the user's input list and reintroducing the same behavior that was fixed in #451.

This PR updates `GlobalPushLogTargets` to use the loop index again as the id parameter when calling CreateLogTarget to keep the same order as user's list and prevent reloads