### PR TITLE
BUG/MEDIUM: handle different endpoint ports

### DIFF
--- a/deploy/tests/e2e/different-ports/config/deploy.yaml.tmpl
+++ b/deploy/tests/e2e/different-ports/config/deploy.yaml.tmpl
@@ -1,0 +1,44 @@
+{{ range $instanceIndex, $instance := .Instances }}
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: http-echo-{{ $instanceIndex }}
+spec:
+  replicas: {{ $instance.Replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: http-echo
+      app.kubernetes.io/instance: http-echo-{{ $instanceIndex }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: http-echo
+        app.kubernetes.io/instance: http-echo-{{ $instanceIndex }}
+    spec:
+      containers:
+        - name: http-echo
+          image: haproxytech/http-echo:latest
+          imagePullPolicy: Never
+          args:
+          - --http={{ $instance.Port }}
+          - --default-response=hostname
+          ports:
+            - name: http
+              containerPort: {{ $instance.Port }}
+              protocol: TCP
+{{- end }}
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: http-echo
+spec:
+  ipFamilyPolicy: RequireDualStack
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+  selector:
+    app.kubernetes.io/name: http-echo

--- a/deploy/tests/e2e/different-ports/config/ingress.yaml.tmpl
+++ b/deploy/tests/e2e/different-ports/config/ingress.yaml.tmpl
@@ -1,0 +1,22 @@
+---
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: http-echo
+  annotations:
+{{range .IngAnnotations}}
+    "{{ .Key }}": "{{ .Value }}"
+{{end}}
+spec:
+  ingressClassName: haproxy
+  rules:
+    - host: {{ .Host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: http-echo
+                port:
+                  name: http

--- a/deploy/tests/e2e/different-ports/different_ports_test.go
+++ b/deploy/tests/e2e/different-ports/different_ports_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 HAProxy Technologies LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e_parallel
+
+package differentports
+
+import (
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/haproxytech/kubernetes-ingress/deploy/tests/e2e"
+)
+
+func (suite *DifferentPortsSuite) Test_Different_Ports() {
+	suite.Run("different port added without scaling", func() {
+		suite.tmplData.Instances = append(suite.tmplData.Instances, instanceTmplData{Port: 8001, Replicas: 1})
+		suite.Require().NoError(suite.test.Apply("config/deploy.yaml.tmpl", suite.test.GetNS(), suite.tmplData))
+		suite.Eventually(suite.everyReplicaReachable, e2e.WaitDuration, e2e.TickDuration)
+	})
+
+	suite.Run("different port added with scaling", func() {
+		suite.tmplData.Instances = append(suite.tmplData.Instances, instanceTmplData{Port: 8002, Replicas: 8})
+		suite.Require().NoError(suite.test.Apply("config/deploy.yaml.tmpl", suite.test.GetNS(), suite.tmplData))
+		suite.Eventually(suite.everyReplicaReachable, e2e.WaitDuration, e2e.TickDuration)
+	})
+
+	suite.Run("different port added while previous port removed", func() {
+		suite.tmplData.Instances = append(suite.tmplData.Instances, instanceTmplData{Port: 8003, Replicas: 1})
+		suite.tmplData.Instances[len(suite.tmplData.Instances)-2].Replicas = 0
+		suite.Require().NoError(suite.test.Apply("config/deploy.yaml.tmpl", suite.test.GetNS(), suite.tmplData))
+		suite.Eventually(suite.everyReplicaReachable, e2e.WaitDuration, e2e.TickDuration)
+	})
+
+	suite.Run("standalone different ports", func() {
+		suite.tmplData.Instances = append(suite.tmplData.Instances, instanceTmplData{Port: 8004, Replicas: 1})
+		suite.tmplData.IngAnnotations = []struct{ Key, Value string }{{Key: "haproxy.org/standalone-backend", Value: "true"}}
+		suite.Require().NoError(suite.test.Apply("config/deploy.yaml.tmpl", suite.test.GetNS(), suite.tmplData))
+		suite.Require().NoError(suite.test.Apply("config/ingress.yaml.tmpl", suite.test.GetNS(), suite.tmplData))
+		suite.Eventually(suite.everyReplicaReachable, e2e.WaitDuration, e2e.TickDuration)
+	})
+}
+
+func (suite *DifferentPortsSuite) everyReplicaReachable() bool {
+	totalReplicas := 0
+	counter := map[int]map[string]int{}
+	for instanceIndex, instance := range suite.tmplData.Instances {
+		totalReplicas += instance.Replicas
+		counter[instanceIndex] = make(map[string]int)
+	}
+
+	for i := 0; i < 2*totalReplicas; i++ {
+		func() {
+			res, cls, err := suite.client.Do()
+			if err != nil {
+				suite.T().Log(err.Error())
+			}
+			defer cls()
+			if res.StatusCode == 200 {
+				body, err := io.ReadAll(res.Body)
+				if err != nil {
+					suite.T().Log(err.Error())
+					return
+				}
+
+				pod := strings.TrimSpace(string(body))
+				instanceIndex, err := strconv.Atoi(strings.Split(pod, "-")[2]) // http-echo-<index>-<hash>-<random>
+				if err != nil {
+					suite.T().Log(err.Error())
+					return
+				}
+				counter[instanceIndex][pod]++
+			}
+		}()
+	}
+
+	for instanceIndex, instance := range suite.tmplData.Instances {
+		if len(counter[instanceIndex]) != instance.Replicas {
+			return false
+		}
+		for _, v := range counter[instanceIndex] {
+			if v != 2 {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/deploy/tests/e2e/different-ports/suite_test.go
+++ b/deploy/tests/e2e/different-ports/suite_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 HAProxy Technologies LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e_parallel
+
+package differentports
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/haproxytech/kubernetes-ingress/deploy/tests/e2e"
+)
+
+type DifferentPortsSuite struct {
+	suite.Suite
+	test     e2e.Test
+	client   *e2e.Client
+	tmplData tmplData
+}
+
+type instanceTmplData struct {
+	Port     int
+	Replicas int
+}
+
+type tmplData struct {
+	IngAnnotations []struct{ Key, Value string }
+	Host           string
+	Instances      []instanceTmplData
+}
+
+func (suite *DifferentPortsSuite) SetupSuite() {
+	var err error
+	suite.test, err = e2e.NewTest()
+	suite.Require().NoError(err)
+	suite.tmplData = tmplData{
+		Host:      suite.test.GetNS() + ".test",
+		Instances: []instanceTmplData{{Port: 8000, Replicas: 1}},
+	}
+	suite.client, err = e2e.NewHTTPClient(suite.tmplData.Host)
+	suite.Require().NoError(err)
+	suite.Require().NoError(suite.test.Apply("config/deploy.yaml.tmpl", suite.test.GetNS(), suite.tmplData))
+	suite.Require().NoError(suite.test.Apply("config/ingress.yaml.tmpl", suite.test.GetNS(), suite.tmplData))
+	suite.Require().Eventually(func() bool {
+		res, cls, err := suite.client.Do()
+		if res == nil {
+			suite.T().Log(err)
+			return false
+		}
+		defer cls()
+		return res.StatusCode == http.StatusOK
+	}, e2e.WaitDuration, e2e.TickDuration)
+}
+
+func (suite *DifferentPortsSuite) TearDownSuite() {
+	suite.test.TearDown()
+}
+
+func TestDifferentPortsSuite(t *testing.T) {
+	suite.Run(t, new(DifferentPortsSuite))
+}

--- a/pkg/haproxy/api/api.go
+++ b/pkg/haproxy/api/api.go
@@ -90,7 +90,7 @@ type HAProxyClient interface { //nolint:interfacebloat
 	SetMapContent(mapFile string, payload []string) error
 	SetServerAddrAndState([]RuntimeServerData) error
 	SetAuxCfgFile(auxCfgFile string)
-	SyncBackendSrvs(backend *store.RuntimeBackend, portUpdated bool) error
+	SyncBackendSrvs(backend *store.RuntimeBackend) error
 	UserListDeleteAll() error
 	UserListExistsByGroup(group string) (bool, error)
 	UserListCreateByGroup(group string, userPasswordMap map[string][]byte) error

--- a/pkg/store/types.go
+++ b/pkg/store/types.go
@@ -76,9 +76,18 @@ type Service struct {
 	Faked       bool
 }
 
+// RuntimeEndpoint describes a single endpoint of a HAProxy backend
+type RuntimeEndpoint struct {
+	Address string
+	Port    int64
+}
+
+// RuntimeEndpoints is a set of different RuntimeEndpoint of a HAProxy backend
+type RuntimeEndpoints = map[RuntimeEndpoint]struct{}
+
 // RuntimeBackend holds the runtime state of an HAProxy backend
 type RuntimeBackend struct {
-	Endpoints       PortEndpoints
+	Endpoints       RuntimeEndpoints
 	Name            string
 	HAProxySrvs     []*HAProxySrv
 	DynUpdateFailed bool


### PR DESCRIPTION
This pull request is a fix for https://github.com/haproxytech/kubernetes-ingress/issues/737

With this change ingress maintains a separate port for each ip address:
- in new RuntimeEndpoint structure for new endpoints
- in HAProxySrv.Port for endpoints that have been configured on backend

and uses per-address port for configuration (from HAProxySrv.Port) in places where common RuntimeBackend.Endpoint.Ports was used before.

Previously k8s representation (PortEndpoints) was used for passing information about new endpoints and only one (the first) port number was used for all addresses even if there were different ports. The new structure does not loose this information.

Apart from automatic tests I briefly tested it manually with ingress / endpoints and very briefly with tcp crd. I haven't manually tested other crds and tcp route. Please let me know if there are other things worth testing I can add new e2e tests or test them manually.