### PR TITLE
DOC/MINOR: update client-ca annotation

### DIFF
--- a/documentation/annotations.md
+++ b/documentation/annotations.md
@@ -402,12 +402,12 @@ auth-realm: Admin Area
 
 Possible values:
 
-- secret path in "namespace/name" format.
+- secret path in "namespace/name" format. Secret should contain the CA certificate in `tls.crt` key. Multiple CAs can be provided by concatenating them in the same `tls.crt` key.
 
 Example:
 
 ```yaml
-client-ca: exp/client-ca.crt
+client-ca: exp/client-ca-secret
 ```
 
 ##### `client-crt-optional`

--- a/documentation/doc.yaml
+++ b/documentation/doc.yaml
@@ -664,12 +664,12 @@ annotations:
     tip:
       - NB, [ssl-offloading](#ssl-offloading) **should be enabled** for TLS authentication to work.
     values:
-      - secret path in "namespace/name" format.
+      - secret path in "namespace/name" format. Secret should contain the CA certificate in `tls.crt` key. Multiple CAs can be provided by concatenating them in the same `tls.crt` key.
     applies_to:
       - configmap
     version_min: "1.6"
     example:
-      - "client-ca: exp/client-ca.crt"
+      - "client-ca: exp/client-ca-secret"
   - title: client-crt-optional
     type: bool
     group: authentication


### PR DESCRIPTION
This pull request updates the documentation for the `client-ca` annotation to clarify how to provide CA certificates and updates the example to use a secret instead of a file path. The changes ensure users understand the expected format and storage of CA certificates for TLS authentication.

Documentation improvements for CA certificate configuration:

* Clarified that the secret referenced by `client-ca` should contain the CA certificate in the `tls.crt` key
* multiple CAs can be provided by concatenating them in the same key. 