### PR TITLE
MINOR: Revise SSL Redirection on default HTTPS port

### DIFF
--- a/.aspell.yml
+++ b/.aspell.yml
@@ -72,5 +72,7 @@ allowed:
   - userlist
   - tmp
   - kubectl
+  - Kubernetes
+  - HTTPS
   - PEM
   - redact


### PR DESCRIPTION
* The default for the controller is to generate redirects to port `8443`, as this port can be bound to in a rootless container.
* Running the container in a Kubernetes setting having a service port mapping to port 443 introduces the need to change this default configuration.
* Having the default HTTPs port `443` appended to the redirect breaks certain caching behaviours and is thus not ideal.
* This commit aims to purely switch the scheme from HTTP to HTTPs without changing anything else about the request, the only user visible change being that the `:443` in the redirect URL is no longer visible.
* fixes #642