### PR TITLE
BUG/MINOR: Prevent user addition with whitespace in password hash

### DIFF
--- a/pkg/annotations/ingress/basicAuth.go
+++ b/pkg/annotations/ingress/basicAuth.go
@@ -1,8 +1,10 @@
 package ingress
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/haproxytech/kubernetes-ingress/pkg/annotations/common"
 	"github.com/haproxytech/kubernetes-ingress/pkg/haproxy/rules"
@@ -76,15 +78,14 @@ func (a ReqAuthAnn) Process(k store.K8s, annotations ...map[string]string) (err 
 		}
 		a.parent.authRule.Credentials = make(map[string][]byte)
 		for u, pwd := range secret.Data {
-			// If the pwd length is 0, we do not create the user in the userlist
+			pwd = bytes.TrimSpace(pwd)
+			// If the pwd is empty or has spaces, we do not create the user in the userlist
 			// This is not a valid setting
-			if len(pwd) > 0 {
-				if pwd[len(pwd)-1] == '\n' {
-					// logger.Warningf("Ingress %s/%s: basic-auth: password for user %s ends with '\\n'. Ignoring last character.", ingress.Namespace, ingress.Name, u)
-					pwd = pwd[:len(pwd)-1]
-				}
-				a.parent.authRule.Credentials[u] = pwd
+			if len(pwd) < 1 || bytes.ContainsFunc(pwd, unicode.IsSpace) {
+				logger.Warningf("Ingress %s/%s: basic-auth: password for user %s is empty or has spaces. Ignoring it.", a.parent.ingress.Namespace, a.parent.ingress.Name, u)
+				continue
 			}
+			a.parent.authRule.Credentials[u] = pwd
 		}
 	default:
 		err = fmt.Errorf("unknown auth-type annotation '%s'", a.name)

--- a/pkg/annotations/ingress/basicAuth.go
+++ b/pkg/annotations/ingress/basicAuth.go
@@ -82,7 +82,17 @@ func (a ReqAuthAnn) Process(k store.K8s, annotations ...map[string]string) (err 
 			// If the pwd is empty or has spaces, we do not create the user in the userlist
 			// This is not a valid setting
 			if len(pwd) < 1 || bytes.ContainsFunc(pwd, unicode.IsSpace) {
-				logger.Warningf("Ingress %s/%s: basic-auth: password for user %s is empty or has spaces. Ignoring it.", a.parent.ingress.Namespace, a.parent.ingress.Name, u)
+				msg := fmt.Sprintf(
+					"basic-auth: invalid password for user %s in secret %s/%s: password is empty or contains whitespace; ignoring it",
+					u, ns, name,
+				)
+				if a.parent.ingress != nil {
+					msg = fmt.Sprintf(
+						"Ingress %s/%s: %s",
+						a.parent.ingress.Namespace, a.parent.ingress.Name, msg,
+					)
+				}
+				logger.Warning(msg)
 				continue
 			}
 			a.parent.authRule.Credentials[u] = pwd


### PR DESCRIPTION
If password hash contains whitespace of any kind, haproxy fails to validate the config and will not start or reload.

According to `man 5 crypt`:
```
Hashed passphrases are always entirely printable ASCII, and do not contain any whitespace or the characters
     ‘:’, ‘;’, ‘*’, ‘!’, or ‘\’.
```
I don't know if it must be this controller's job to validate all of that. But, whitespace in the password does brake it from generating valid HAProxy config, so that is a bug.
Also, I think that emitting a warning is helpful for admins to figure out why some user cannot login.

/cc @ivanmatmati: I talked to you on Slack
/cc @hdurand0710: You fixed a bug related