### PR TITLE
BUILD/MINOR: Switch order on inside c.Start(), so restart will work and run Start() synchronously and split SyncData() into its own goroutine

### DIFF
--- a/deploy/tests/integration/base-suite.go
+++ b/deploy/tests/integration/base-suite.go
@@ -152,7 +152,8 @@ func (suite *BaseSuite) StartController() {
 	annotations.InitCfgSnippet()
 	annotations.DisableConfigSnippets(testController.OSArgs.DisableConfigSnippets)
 
-	go testController.Controller.Start()
+	testController.Controller.Start()
+	go testController.Controller.SyncData()
 }
 
 func (suite *BaseSuite) StopController() {

--- a/deploy/tests/tnr/routeacl/suite_test.go
+++ b/deploy/tests/tnr/routeacl/suite_test.go
@@ -126,7 +126,8 @@ func (suite *UseBackendSuite) UseBackendFixture() (eventChan chan k8ssync.SyncDa
 		WithUpdateStatusManager(&updateStatusManager{}).
 		WithArgs(osArgs).Build()
 
-	go controller.Start()
+	controller.Start()
+	go controller.SyncData()
 
 	// Now sending store events for test setup
 	ns := store.Namespace{Name: "ns", Status: store.ADDED}
@@ -239,7 +240,8 @@ func (suite *UseBackendSuite) NonWildcardHostFixture() (eventChan chan k8ssync.S
 		WithUpdateStatusManager(&updateStatusManager{}).
 		WithArgs(osArgs).Build()
 
-	go controller.Start()
+	controller.Start()
+	go controller.SyncData()
 
 	// Now sending store events for test setup
 	ns := store.Namespace{Name: "ns", Status: store.ADDED}
@@ -345,7 +347,8 @@ func (suite *UseBackendSuite) WildcardHostFixture() (eventChan chan k8ssync.Sync
 		WithUpdateStatusManager(&updateStatusManager{}).
 		WithArgs(osArgs).Build()
 
-	go controller.Start()
+	controller.Start()
+	go controller.SyncData()
 
 	// Now sending store events for test setup
 	ns := store.Namespace{Name: "ns", Status: store.ADDED}

--- a/deploy/tests/ut/acls/suite_test.go
+++ b/deploy/tests/ut/acls/suite_test.go
@@ -108,7 +108,8 @@ func (suite *ACLSuite) UseACLFixture() (eventChan chan k8ssync.SyncDataEvent) {
 		WithUpdateStatusManager(&FakeUpdateSatusManager{}).
 		WithArgs(osArgs).Build()
 
-	go controller.Start()
+	controller.Start()
+	go controller.SyncData()
 
 	backend := v3.Backend{
 		ObjectMeta: metav1.ObjectMeta{

--- a/deploy/tests/ut/httprequests/suite_test.go
+++ b/deploy/tests/ut/httprequests/suite_test.go
@@ -108,7 +108,8 @@ func (suite *HTTPRequestsSuite) UseHTTPRequestsFixture() (eventChan chan k8ssync
 		WithUpdateStatusManager(&FakeUpdateSatusManager{}).
 		WithArgs(osArgs).Build()
 
-	go controller.Start()
+	controller.Start()
+	go controller.SyncData()
 
 	backend := v3.Backend{
 		ObjectMeta: metav1.ObjectMeta{

--- a/main.go
+++ b/main.go
@@ -177,8 +177,9 @@ func main() {
 
 	c.SetGatewayAPIInstalled(isGatewayAPIInstalled)
 
+	c.Start()
 	go k.MonitorChanges(eventChan, stop, osArgs, isGatewayAPIInstalled)
-	go c.Start()
+	go c.SyncData()
 	// Catch QUIT signals
 	signalC := make(chan os.Signal, 1)
 	signal.Notify(signalC, os.Interrupt, syscall.SIGTERM, syscall.SIGUSR1)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -84,6 +84,9 @@ func (c *HAProxyController) clientAPIClosure(fn func() error) (err error) {
 
 // Start initializes and runs HAProxyController
 func (c *HAProxyController) Start() {
+	_, errStart := (c.haproxy.Service("start"))
+	logger.Panic(errStart)
+
 	logger.Panic(c.clientAPIClosure(func() error {
 		err := c.haproxy.PeerEntryDelete("localinstance", "local")
 		if err != nil {
@@ -100,8 +103,6 @@ func (c *HAProxyController) Start() {
 	c.initHandlers()
 	logger.Error(c.setupHAProxyRules())
 	logger.Error(os.Chdir(c.haproxy.Env.CfgDir))
-	_, errStart := (c.haproxy.Service("start"))
-	logger.Panic(errStart)
 
 	c.SyncData()
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -103,8 +103,6 @@ func (c *HAProxyController) Start() {
 	c.initHandlers()
 	logger.Error(c.setupHAProxyRules())
 	logger.Error(os.Chdir(c.haproxy.Env.CfgDir))
-
-	c.SyncData()
 }
 
 // Stop handles shutting down HAProxyController

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -109,8 +109,6 @@ func (c *HAProxyController) Start() {
 	c.initHandlers()
 	logger.Error(c.setupHAProxyRules())
 	logger.Error(os.Chdir(c.haproxy.Env.CfgDir))
-
-	c.SyncData()
 }
 
 // Stop handles shutting down HAProxyController

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -89,6 +89,9 @@ func (c *HAProxyController) clientAPIClosure(fn func() error) (err error) {
 
 // Start initializes and runs HAProxyController
 func (c *HAProxyController) Start() {
+	_, errStart := (c.haproxy.Service("start"))
+	logger.Panic(errStart)
+
 	logger.Panic(c.clientAPIClosure(func() error {
 		err := c.haproxy.PeerEntryDelete("localinstance", "local")
 		if err != nil {
@@ -106,8 +109,6 @@ func (c *HAProxyController) Start() {
 	c.initHandlers()
 	logger.Error(c.setupHAProxyRules())
 	logger.Error(os.Chdir(c.haproxy.Env.CfgDir))
-	_, errStart := c.haproxy.Service("start")
-	logger.Panic(errStart)
 
 	c.SyncData()
 }


### PR DESCRIPTION
**Problem**

When running the controller in external mode (e.g. under systemd), systemctl restart hangs ~50% of the time. The controller gets stuck and never processes Kubernetes events.

**Root Cause**

On restart, the old HAProxy may still be alive briefly. Start() previously ran APICommitTransaction calls before Service("start"), which stripped the daemon directive from the on-disk config. When the old HAProxy finally exited and a new one launched, it ran in the foreground, blocking forever.

**Fix**

- Move Service("start") to the top of Start(), before any API transactions can rewrite the config. This restores the ordering from the 3.0.x series.
- Extract SyncData() out of Start() into its own goroutine and run Start() synchronously before launching the event producer. This ensures full initialization completes before any events or signals can arrive.

