### PR TITLE
Case-insensitive path matching support added for ingress path

### DIFF
--- a/documentation/doc.yaml
+++ b/documentation/doc.yaml
@@ -438,6 +438,14 @@ image_arguments:
     version_min: "3.2"
     values:
       - Boolean value, just need to declare the flag
+  - argument: --case-insensitive-path-match
+    description: |-
+        Enable case-insensitive path matching for Ingress resources.
+        By default, path matching is case-sensitive. If enabled, HAProxy will perform case-insensitive matching for all Ingress paths. 
+    example: --case-insensitive-path-match
+    version_min: "3.2"
+    values:
+      - Boolean value, just need to declare the flag to enable
 groups:
   config-snippet:
     header: |-

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -288,6 +288,12 @@ func (c *HAProxyController) setupHAProxyRules() error {
 			ForwardedProto: true,
 		}, false),
 	)
+
+	pathExpr := "path"
+	if c.osArgs.CaseInsensitive {
+		pathExpr = "path,lower"
+	}
+
 	for _, frontend := range []string{c.haproxy.FrontHTTP, c.haproxy.FrontHTTPS} {
 		errs.Add(
 			// txn.base var used for logging
@@ -300,7 +306,7 @@ func (c *HAProxyController) setupHAProxyRules() error {
 			c.haproxy.AddRule(frontend, rules.ReqSetVar{
 				Name:       "path",
 				Scope:      "txn",
-				Expression: "path",
+				Expression: pathExpr,
 			}, false),
 			c.haproxy.AddRule(frontend, rules.ReqSetVar{
 				Name:       "host",

--- a/pkg/utils/flags.go
+++ b/pkg/utils/flags.go
@@ -127,4 +127,5 @@ type OSArgs struct {
 	DisableIngressStatusUpdate        bool           `long:"disable-ingress-status-update" description:"If true, disables updating the status field of Ingress resources"`
 	EnableCustomAnnotationsOnIngress  bool           `long:"enable-custom-annotations-on-ingress" description:"allow custom user annotations on ingress"`
 	CustomValidationRules             NamespaceValue `long:"custom-validation-rules" description:"custom validation rules object" default:""`
+	CaseInsensitive                   bool           `long:"case-insensitive-path-match" description:"enable case-insensitive path matching"`
 }


### PR DESCRIPTION
Normally, haproxy-kubernetes-ingress performs path matching in a case-sensitive manner. However, ingress-nginx supports case-insensitive path matching. During migrations from ingress-nginx to haproxy-kubernetes-ingress, some projects may require case-insensitive path matching behavior.

This change introduces an optional feature that enables case-insensitive path matching.

The feature can be enabled by passing an extra argument in the Helm chart configuration:

extraArgs: 
 - --case-insensitive-path-match
 
 
 kubernetes ingress example;
 
 spec:
  ingressClassName: haproxy
  rules:
    - host: example.com
      http:
        paths:
          - path: /example-api
            pathType: ImplementationSpecific
            backend:
              service:
                name: example-api
                port:
                  number: 80
                  

this ingress path match with example.com/example-api, example.com/Example-api, example.com/EXAMPLE-api etc.
