### PR TITLE
BUG/MAJOR: service: deep-copy cr-backend spec to fix cross-service server contamination

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -200,6 +200,16 @@ func (s *Service) getBackendModel(store store.K8s, a annotations.Annotations, cl
 	// get/create backend Model
 	backend, err = annotations.ModelBackend("cr-backend", s.resource.Namespace, store, s.annotations...)
 	logger.Warning(err)
+	if backend != nil {
+		// Deep-copy the CR object before mutating it: multiple services may share the
+		// same cr-backend annotation and therefore the same *v3.BackendSpec pointer in
+		// the store.  Without a copy, mutations below (BackendBase.Name, Servers map,
+		// etc.) bleed across services, causing one backend's server list to contaminate
+		// another's.
+		var backendCopy v3.BackendSpec
+		backend.DeepCopyInto(&backendCopy)
+		backend = &backendCopy
+	}
 	if backend == nil {
 		backend = &v3.BackendSpec{
 			Backend: models.Backend{


### PR DESCRIPTION
https://github.com/haproxytech/kubernetes-ingress/issues/795
we have same bug, this fix the bug

this cause way bigger issue since we run multiple backends with external mode.

the actually backend SRV would duplicate and override each other, its not really a drift but totally broke when pod ip gets changed on a rolling upgrade case

deepcopy would avoid this

the actually block that cause it
https://github.com/haproxytech/kubernetes-ingress/blob/master/pkg/service/service.go#L227-L238

