### PR TITLE
BUG/MEDIUM: ingress: keep https frontend for REQ_DENY/REQ_CAPTURE when SSLPassthrough is cluster-wide

### DIFF
--- a/deploy/tests/e2e/https/allowlist_passthrough_test.go
+++ b/deploy/tests/e2e/https/allowlist_passthrough_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 HAProxy Technologies LLC
+// Copyright 2026 HAProxy Technologies LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,13 +24,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-// AllowListWithClusterPassthroughSuite reproduces a regression where an
-// unrelated ingress using ssl-passthrough elsewhere in the cluster flips the
-// controller-wide haproxy.SSLPassthrough flag, which in turn caused
-// allow-list/deny-list rules on a *different*, non-passthrough ingress to be
-// dropped from the "https" frontend - the frontend where that ingress's own
-// TLS-terminated traffic actually lands. The allow-list then went
-// unenforced for that ingress's real traffic.
+// Adding AllowListWithClusterPassthroughSuite, just to be able to debug directly here and not from CRDSuite
 type AllowListWithClusterPassthroughSuite struct {
 	HTTPSSuite
 }
@@ -39,11 +33,13 @@ func TestAllowListWithClusterPassthroughSuite(t *testing.T) {
 	suite.Run(t, new(AllowListWithClusterPassthroughSuite))
 }
 
-func (suite *AllowListWithClusterPassthroughSuite) Test_AllowList_Enforced_When_Another_Ingress_Uses_SSLPassthrough() {
+func (suite *AllowListWithClusterPassthroughSuite) Test_AllowList_With_ClusterPassthrough() {
 	// A second, unrelated ingress using ssl-passthrough. Its mere presence in
 	// the cluster flips haproxy.SSLPassthrough, which must not affect rule
-	// placement for other, non-passthrough ingresses.
-	defer suite.test.Delete("config/passthrough-sidecar-delete.yaml")
+	// placement for other, non-passthrough ingresses. Left in place for the
+	// rest of the suite run; TearDownSuite deletes the whole test namespace
+	// (Test.Delete has no way to target this dynamic namespace, so a
+	// per-test kubectl delete here would silently no-op against the wrong one).
 	passthroughData := tmplData{
 		Host: "passthrough-sidecar." + suite.test.GetNS() + ".test",
 		Port: "https",

--- a/deploy/tests/e2e/https/allowlist_passthrough_test.go
+++ b/deploy/tests/e2e/https/allowlist_passthrough_test.go
@@ -1,0 +1,74 @@
+// Copyright 2019 HAProxy Technologies LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e_https
+
+package https
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/haproxytech/kubernetes-ingress/deploy/tests/e2e"
+	"github.com/stretchr/testify/suite"
+)
+
+// AllowListWithClusterPassthroughSuite reproduces a regression where an
+// unrelated ingress using ssl-passthrough elsewhere in the cluster flips the
+// controller-wide haproxy.SSLPassthrough flag, which in turn caused
+// allow-list/deny-list rules on a *different*, non-passthrough ingress to be
+// dropped from the "https" frontend - the frontend where that ingress's own
+// TLS-terminated traffic actually lands. The allow-list then went
+// unenforced for that ingress's real traffic.
+type AllowListWithClusterPassthroughSuite struct {
+	HTTPSSuite
+}
+
+func TestAllowListWithClusterPassthroughSuite(t *testing.T) {
+	suite.Run(t, new(AllowListWithClusterPassthroughSuite))
+}
+
+func (suite *AllowListWithClusterPassthroughSuite) Test_AllowList_Enforced_When_Another_Ingress_Uses_SSLPassthrough() {
+	// A second, unrelated ingress using ssl-passthrough. Its mere presence in
+	// the cluster flips haproxy.SSLPassthrough, which must not affect rule
+	// placement for other, non-passthrough ingresses.
+	defer suite.test.Delete("config/passthrough-sidecar-delete.yaml")
+	passthroughData := tmplData{
+		Host: "passthrough-sidecar." + suite.test.GetNS() + ".test",
+		Port: "https",
+		IngAnnotations: []struct{ Key, Value string }{
+			{"ssl-passthrough", "'true'"},
+		},
+	}
+	suite.Require().NoError(suite.test.Apply("config/passthrough-sidecar.yaml.tmpl", suite.test.GetNS(), passthroughData))
+
+	// The ingress under test: allow-list only, no ssl-passthrough of its own.
+	// suite.client (created in BeforeTest) targets suite.tmplData.Host over HTTPS.
+	suite.tmplData.IngAnnotations = []struct{ Key, Value string }{
+		{"allow-list", "6.6.6.6"},
+	}
+	suite.Require().NoError(suite.test.Apply("config/ingress.yaml.tmpl", suite.test.GetNS(), suite.tmplData))
+
+	suite.Eventually(func() bool {
+		res, cls, err := suite.client.Do()
+		if res == nil {
+			suite.T().Log(err)
+			return false
+		}
+		defer cls()
+		// The test client is never 6.6.6.6, so its HTTPS request must be
+		// denied - even though a coexisting ingress uses ssl-passthrough.
+		return res.StatusCode == http.StatusForbidden
+	}, e2e.WaitDuration, e2e.TickDuration, "expected HTTPS request to the non-passthrough ingress to be blocked by allow-list")
+}

--- a/deploy/tests/e2e/https/config/passthrough-sidecar-delete.yaml
+++ b/deploy/tests/e2e/https/config/passthrough-sidecar-delete.yaml
@@ -1,4 +1,0 @@
-kind: Ingress
-apiVersion: networking.k8s.io/v1
-metadata:
-  name: http-echo-passthrough-sidecar

--- a/deploy/tests/e2e/https/config/passthrough-sidecar-delete.yaml
+++ b/deploy/tests/e2e/https/config/passthrough-sidecar-delete.yaml
@@ -1,0 +1,4 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: http-echo-passthrough-sidecar

--- a/deploy/tests/e2e/https/config/passthrough-sidecar.yaml.tmpl
+++ b/deploy/tests/e2e/https/config/passthrough-sidecar.yaml.tmpl
@@ -1,0 +1,21 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: http-echo-passthrough-sidecar
+  annotations:
+    {{range .IngAnnotations}}
+    {{ .Key }}: {{ .Value}}
+    {{end}}
+spec:
+  ingressClassName: haproxy
+  rules:
+    - host: {{ .Host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: http-echo
+                port:
+                  name: {{ .Port }}

--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -166,7 +166,9 @@ func addRules(list rules.List, h haproxy.HAProxy, ingressRule bool) []rules.Rule
 			}
 		case rules.REQ_DENY, rules.REQ_CAPTURE:
 			if haproxy.SSLPassthrough {
-				frontends = []string{h.FrontHTTP, h.FrontSSL}
+				// FrontHTTPS still terminates non-passthrough ingresses' TLS traffic
+				// (funnelled in via FrontSSL's default backend), so it needs the rule too.
+				frontends = []string{h.FrontHTTP, h.FrontSSL, h.FrontHTTPS}
 			}
 		}
 		for _, frontend := range frontends {

--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -167,7 +167,7 @@ func addRules(list rules.List, h haproxy.HAProxy, ingressRule bool) []rules.Rule
 		case rules.REQ_DENY, rules.REQ_CAPTURE:
 			if haproxy.SSLPassthrough {
 				// FrontHTTPS still terminates non-passthrough ingresses' TLS traffic
-				// (funnelled in via FrontSSL's default backend), so it needs the rule too.
+				// (funnelled in via FrontSSL's default backend), so it needs the rule too
 				frontends = []string{h.FrontHTTP, h.FrontSSL, h.FrontHTTPS}
 			}
 		}


### PR DESCRIPTION
## Summary

`haproxy.SSLPassthrough` is a controller-wide flag: it becomes true as soon as any single ingress in the cluster uses `ssl-passthrough`, not just the ingress currently being processed. `addRules()` used that flag to decide where an ingress's allow-list/deny-list (`REQ_DENY`) or capture (`REQ_CAPTURE`) rule gets attached, swapping `FrontHTTPS` for `FrontSSL` whenever the flag was true — for *every* ingress, including ones that never opted into ssl-passthrough themselves.

But a non-passthrough ingress's TLS traffic still terminates on `FrontHTTPS`: `HTTPS.toggleSSLPassthrough` replaces `FrontHTTPS`'s public binds with an internal PROXY-protocol socket once `SSLPassthrough` is active, and `FrontSSL`'s default backend (`ssl-backend`) forwards non-passthrough SNIs there. Dropping `FrontHTTPS` from the rule's frontends left that traffic completely unchecked by its own allow-list/deny-list — independent of, and in addition to, the intermittent frontend-selection bug fixed in #770 / 79d754ae. That earlier fix made frontend selection *stable*; it didn't change that the selection itself drops `FrontHTTPS` whenever any ingress anywhere uses passthrough.

Observed live: an ingress with `haproxy.org/allow-list` sharing a cluster with an unrelated `ssl-passthrough` ingress let non-allow-listed source IPs reach the backend over HTTPS (TCP and QUIC/HTTP3) with no enforcement at all, while the same allow-list correctly blocked plain HTTP.

## Fix

Keep `FrontHTTPS` in the frontend list alongside `FrontHTTP` and `FrontSSL` so both traffic paths — genuine SNI-routed passthrough and internally-forwarded TLS termination — get the rule. Confirmed this is provably safe for the mixed-cluster case: a non-passthrough ingress's host is never written into the SNI map, so the extra `FrontSSL` placement it already had is inert there; the missing piece was purely `FrontHTTPS`.

## Test plan
- [x] `go build ./...` and `go vet` pass
- [x] Added `deploy/tests/e2e/https/allowlist_passthrough_test.go`: deploys an unrelated `ssl-passthrough` sidecar ingress alongside a plain `allow-list` ingress and asserts the latter's HTTPS traffic is still denied for a non-allow-listed client
- [x] `go build -tags e2e_https ./deploy/tests/e2e/...` passes
- [ ] Not run against a live cluster (no local e2e environment) — would appreciate a maintainer running the e2e suite