### PR TITLE
BUG/MEDIUM: controller: stop duplicating default local backend config snippet

### DIFF
--- a/pkg/controller/global.go
+++ b/pkg/controller/global.go
@@ -213,8 +213,6 @@ func populateDefaultLocalBackendResources(k8sStore store.K8s, podNs string, defa
 		}
 		k8sStore.EventEndpoints(controllerNs, endpoints, nil)
 		logger.Debug("default backend event endpoints processed")
-	} else {
-		defaultLocalService.Annotations = k8sStore.ConfigMaps.Main.Annotations
 	}
 	return nil
 }


### PR DESCRIPTION
Overwriting defaultLocalService.Annotations with ConfigMap annotations made the global backend-config-snippet get applied twice to the default local backend, breaking HAProxy reload.

Commit 3ff14e4 previously fixed this, but the bug was reintroduced in fb58ed3.

Fixes #829.