### PR TITLE
BUG/MEDIUM: ssl-passthrough: keep allow/deny-list on the https frontend

### DIFF
--- a/deploy/tests/e2e/https/allowlist_passthrough_test.go
+++ b/deploy/tests/e2e/https/allowlist_passthrough_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 HAProxy Technologies LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e_https
+
+package https
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/haproxytech/kubernetes-ingress/deploy/tests/e2e"
+	"github.com/stretchr/testify/suite"
+)
+
+// Adding AllowListWithClusterPassthroughSuite, just to be able to debug directly here and not from CRDSuite
+type AllowListWithClusterPassthroughSuite struct {
+	HTTPSSuite
+}
+
+func TestAllowListWithClusterPassthroughSuite(t *testing.T) {
+	suite.Run(t, new(AllowListWithClusterPassthroughSuite))
+}
+
+func (suite *AllowListWithClusterPassthroughSuite) Test_AllowList_With_ClusterPassthrough() {
+	// A second, unrelated ingress using ssl-passthrough. Its mere presence in
+	// the cluster flips haproxy.SSLPassthrough, which must not affect rule
+	// placement for other, non-passthrough ingresses.
+	defer func() {
+		suite.Require().NoError(suite.test.Delete("config/passthrough-sidecar-delete.yaml"))
+	}()
+	sidecarHost := "passthrough-sidecar." + suite.test.GetNS() + ".test"
+	passthroughData := tmplData{
+		Host: sidecarHost,
+		Port: "https",
+		IngAnnotations: []struct{ Key, Value string }{
+			{"ssl-passthrough", "'true'"},
+		},
+	}
+	suite.Require().NoError(suite.test.Apply("config/passthrough-sidecar.yaml.tmpl", suite.test.GetNS(), passthroughData))
+
+	// Confirm the sidecar's ssl-passthrough is genuinely active before relying
+	// on it as this test's precondition - mirrors passthrough_test.go's own
+	// Reach_Backend check. The echo backend only reports a TLS SNI when
+	// HAProxy relayed a raw passthrough connection instead of terminating
+	// TLS itself, so this can't pass unless SSLPassthrough actually flipped.
+	sidecarClient, err := e2e.NewHTTPSClient(sidecarHost)
+	suite.Require().NoError(err)
+	suite.Eventually(func() bool {
+		res, cls, err := sidecarClient.Do()
+		if res == nil {
+			suite.T().Log(err)
+			return false
+		}
+		defer cls()
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			return false
+		}
+		type echoServerResponse struct {
+			TLS struct {
+				SNI string `json:"sni"`
+			} `json:"tls"`
+		}
+		response := &echoServerResponse{}
+		if err := json.Unmarshal(body, response); err != nil {
+			return false
+		}
+		return response.TLS.SNI == sidecarHost
+	}, e2e.WaitDuration, e2e.TickDuration, "expected the sidecar ssl-passthrough ingress to be active before testing the main ingress's allow-list")
+
+	// The ingress under test: allow-list only, no ssl-passthrough of its own.
+	// suite.client (created in BeforeTest) targets suite.tmplData.Host over HTTPS.
+	suite.tmplData.IngAnnotations = []struct{ Key, Value string }{
+		{"allow-list", "6.6.6.6"},
+	}
+	suite.Require().NoError(suite.test.Apply("config/ingress.yaml.tmpl", suite.test.GetNS(), suite.tmplData))
+
+	suite.Eventually(func() bool {
+		res, cls, err := suite.client.Do()
+		if res == nil {
+			suite.T().Log(err)
+			return false
+		}
+		defer cls()
+		// The test client is never 6.6.6.6, so its HTTPS request must be
+		// denied - even though a coexisting ingress uses ssl-passthrough.
+		return res.StatusCode == http.StatusForbidden
+	}, e2e.WaitDuration, e2e.TickDuration, "expected HTTPS request to the non-passthrough ingress to be blocked by allow-list")
+
+	// Positive control on the same ingress/host/frontend: widen the allow-list
+	// to everyone and confirm the same client now gets through. FrontHTTPS is
+	// shared by every TLS-terminated ingress in the cluster, so proving the
+	// prior 403 alone doesn't rule out a regression that makes the deny
+	// unconditional (denies everyone) rather than correctly scoped.
+	suite.tmplData.IngAnnotations = []struct{ Key, Value string }{
+		{"allow-list", "0.0.0.0/0"},
+	}
+	suite.Require().NoError(suite.test.Apply("config/ingress.yaml.tmpl", suite.test.GetNS(), suite.tmplData))
+
+	suite.Eventually(func() bool {
+		res, cls, err := suite.client.Do()
+		if res == nil {
+			suite.T().Log(err)
+			return false
+		}
+		defer cls()
+		return res.StatusCode == http.StatusOK
+	}, e2e.WaitDuration, e2e.TickDuration, "expected HTTPS request to succeed once the allow-list is widened to everyone")
+}

--- a/deploy/tests/e2e/https/config/passthrough-sidecar-delete.yaml
+++ b/deploy/tests/e2e/https/config/passthrough-sidecar-delete.yaml
@@ -1,0 +1,5 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: http-echo-passthrough-sidecar
+  namespace: e2e-tests-https

--- a/deploy/tests/e2e/https/config/passthrough-sidecar.yaml.tmpl
+++ b/deploy/tests/e2e/https/config/passthrough-sidecar.yaml.tmpl
@@ -1,0 +1,21 @@
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: http-echo-passthrough-sidecar
+  annotations:
+    {{range .IngAnnotations}}
+    {{ .Key }}: {{ .Value}}
+    {{end}}
+spec:
+  ingressClassName: haproxy
+  rules:
+    - host: {{ .Host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: http-echo
+                port:
+                  name: {{ .Port }}

--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -266,7 +266,10 @@ func declareRules(list rules.List, h haproxy.HAProxy, ingressRule bool) {
 			}
 		case rules.REQ_DENY, rules.REQ_CAPTURE:
 			if haproxy.SSLPassthrough {
-				frontends = []string{h.FrontHTTP, h.FrontSSL}
+				// FrontHTTPS also terminates the TLS traffic of an ingress that does
+				// not use ssl-passthrough. FrontSSL sends this traffic to FrontHTTPS
+				// with its default backend. So FrontHTTPS must also get the rule.
+				frontends = []string{h.FrontHTTP, h.FrontSSL, h.FrontHTTPS}
 			}
 		}
 		for _, frontend := range frontends {


### PR DESCRIPTION
## Problem
This fixes issue #832. `haproxy.SSLPassthrough` is controller-wide: it becomes true when any ingress uses `ssl-passthrough`. While it is true, `addRules()` dropped the `https` frontend from every ingress's allow-list/deny-list rule. But a non-passthrough ingress still terminates its TLS on that frontend (via `FrontSSL`'s default backend). So the allow-list failed open on HTTPS and QUIC, while plain HTTP stayed filtered. This differs from `79d754ae`, which only made the flag value stable in one pass.

## Fix
Keep `FrontHTTPS` in the frontend list. For a non-passthrough ingress the extra `FrontSSL` placement does nothing, because its host is never in the SNI map.

## Test
An `ssl-passthrough` ingress runs next to a plain allow-list ingress. The test asserts the allow-list ingress returns 403 over HTTPS for an off-list client, and 200 after the allow-list widens to `0.0.0.0/0`.

Supersedes #831 (test-only demonstration).