### PR TITLE
BUILD/MINOR: ci: restrict token permissions and stop persisting credentials

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,10 +1,16 @@
 name: CI
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   check:
     if: ${{ github.event_name == 'pull_request' }}
     name: HAProxy check commit message
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: commit-policy
         uses: docker://ghcr.io/haproxytech/commit-check:latest
         env:
@@ -23,6 +25,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set the expected Go version
         run: |
           GOMOD_VERSION=$(cat go.mod | grep -i "^go " | sed -e "s/go //g")
@@ -57,6 +61,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -80,6 +86,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -104,6 +112,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -131,6 +141,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -159,6 +171,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/docker_auto_release.yml
+++ b/.github/workflows/docker_auto_release.yml
@@ -51,6 +51,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Prepare env variables
         id: env

--- a/.github/workflows/docker_auto_release.yml
+++ b/.github/workflows/docker_auto_release.yml
@@ -3,6 +3,8 @@ on:
   push:
     tags:
       - "v*"
+permissions: {}
+
 jobs:
   main:
     runs-on: large_runner

--- a/.github/workflows/docker_description.yml
+++ b/.github/workflows/docker_description.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - README.md
   workflow_dispatch:
+permissions:
+  contents: read
+
 jobs:
   main:
     runs-on: large_runner

--- a/.github/workflows/docker_description.yml
+++ b/.github/workflows/docker_description.yml
@@ -18,6 +18,8 @@ jobs:
       - name: Check out repo
         id: checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Update Docker Hub description
         id: description

--- a/.github/workflows/docker_description.yml
+++ b/.github/workflows/docker_description.yml
@@ -2,7 +2,7 @@ name: Update Docker Hub description
 on:
   push:
     branches:
-      - main
+      - master
     paths:
       - README.md
   workflow_dispatch:

--- a/.github/workflows/docker_manual_release.yml
+++ b/.github/workflows/docker_manual_release.yml
@@ -49,6 +49,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Reposition to latest tag
         run: |

--- a/.github/workflows/docker_manual_release.yml
+++ b/.github/workflows/docker_manual_release.yml
@@ -1,6 +1,8 @@
 name: Manual build latest tag and push to Docker Hub
 on:
   workflow_dispatch:
+permissions: {}
+
 jobs:
   main:
     runs-on: large_runner

--- a/.github/workflows/docker_nightly.yml
+++ b/.github/workflows/docker_nightly.yml
@@ -5,6 +5,8 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   main:
     if: ${{ github.repository_owner == 'haproxytech' }}

--- a/.github/workflows/docker_nightly.yml
+++ b/.github/workflows/docker_nightly.yml
@@ -53,6 +53,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Prepare env variables
         id: env

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           # we have to fetch all history to be able to generate the release note. c.f. https://goreleaser.com/ci/actions/.
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -3,6 +3,9 @@ on:
   push:
     tags:
       - "*"
+permissions:
+  contents: write  # goreleaser publishes the release
+
 jobs:
   goreleaser:
     runs-on: large_runner


### PR DESCRIPTION
Three small, independent changes to the workflows. Each one is its own commit and can be
dropped on its own.

### 1. Restrict the token permissions of every workflow

A workflow without a `permissions` key gets the default token of the repository, which on
a repository of this age is often read and write on every scope. The three docker
workflows already declare `contents: read` / `packages: write` on their job.
`actions.yml` and `goreleaser.yml` declare nothing, and `goreleaser.yml` publishes the
release on a tag push with that token.

Each workflow now carries a top-level `permissions` key with what it uses today:

| workflow | permissions |
|---|---|
| `actions.yml` | `contents: read`, plus `pull-requests: read` on the check job |
| `goreleaser.yml` | `contents: write` |
| `docker_description.yml` | `contents: read` |
| `docker_nightly.yml`, `docker_auto_release.yml`, `docker_manual_release.yml` | `{}`, the job already declares its own |

No job loses an access it was making use of.

### 2. Stop persisting the token in the checkout

`actions/checkout` writes the token it used into `.git/config` unless told not to. It
stays there for the rest of the job, so every command that runs after the checkout can
read it, including the build and the test of pull request code.

`persist-credentials: false` is set on each checkout. No step talks to git with that
credential afterwards: goreleaser reads the history for its release note and publishes
over the API with `GITHUB_TOKEN`, and the docker workflows only read the tree.

### 3. Trigger the Docker Hub description update on master

`docker_description.yml` watches a push on `main`. The default branch is `master`, so the
workflow has never run and the description on Docker Hub is not following `README.md`.

### Checks

YAML parses on all six files, `make check-commit` is clean. Nothing here changes what the
workflows do, only the token they do it with, so the effect is visible on the first run
of each.

### Not in this PR

Two things I left out on purpose, happy to open them separately if they are of interest:

- **Pinning the actions by SHA.** `docker/login-action@v1`, `build-push-action@v2`,
  `setup-qemu-action@v1` and `setup-buildx-action@v1` have not moved in four to five
  years, and `actions.yml` pulls `docker://ghcr.io/haproxytech/commit-check:latest` on
  every pull request, including from forks. Worth doing together with a bot that keeps
  the digests current, which is the subject of the issue below.
- **Dependency updates and vulnerability scanning** (Renovate, govulncheck): #842
