### PR TITLE
BUILD/MINOR: strip the symbol table and trim the build path from the binary

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,7 +20,15 @@ builds:
       - CGO_ENABLED=0
     binary: haproxy-ingress-controller
     id: my-build
+    flags:
+      # keeps the build path of the machine that produced the binary out of it
+      - -trimpath
     ldflags:
+      # drops the symbol table, and the DWARF data with it: the linker derives
+      # -w from -s unless -w is given explicitly. about 29 MB of the binary.
+      # the pclntab is untouched, so a panic still prints a stack trace with
+      # function names and line numbers, and pprof still symbolises.
+      - -s
       - -X "main.GitRepo={{.GitURL}}"
       - -X "main.GitTag={{.Tag}}"
       - -X "main.GitCommit={{.ShortCommit}}"

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -56,7 +56,8 @@ RUN mkdir -p /var/run/vars && \
     cd /src && \
     git describe --abbrev=0 --tags > /var/run/vars/GIT_LAST_TAG || echo "dev" > /var/run/vars/GIT_LAST_TAG && \
     CGO_ENABLED=0 go build \
-        -ldflags "-X github.com/haproxytech/kubernetes-ingress/pkg/version.GitTag=$(cat /var/run/vars/GIT_LAST_TAG)" \
+        -trimpath \
+        -ldflags "-s -X github.com/haproxytech/kubernetes-ingress/pkg/version.GitTag=$(cat /var/run/vars/GIT_LAST_TAG)" \
         -o fs/haproxy-ingress-controller .
 
 FROM haproxytech/haproxy-alpine:3.2


### PR DESCRIPTION
Neither build path passes `-s -w`: not `.goreleaser.yml`, not `build/Dockerfile:53`. Both
ship the symbol table and the DWARF data.

### Measured

`linux/amd64`, same commit, same `CGO_ENABLED=0`:

| build | size | |
|---|---|---|
| as today | 98.7 MB | |
| `-ldflags "-s"` | 69.7 MB | −29.4% |
| `+ -trimpath` | 69.5 MB | −29.5% |

Close to 30 MB per image, pulled on every node of every cluster.

### Stack traces are not what is lost

This is the usual objection, and it does not hold. A Go stack trace is read from the
`pclntab`, which the linker keeps whatever the flags are: `-s` drops the symbol table and
the DWARF data, and touches neither the `pclntab`. Same panic, two binaries:

```
### without -s                      ### with -s
panic: index out of range [1]       panic: index out of range [1]

goroutine 1 [running]:              goroutine 1 [running]:
main.explode(...)                   main.explode(...)
	/…/main.go:3                       /…/main.go:3
main.main()                         main.main()
```

Identical. `net/http/pprof` is unaffected for the same reason: symbolisation happens in
the runtime, from the `pclntab`, not from the symbol table.

`-w` is deliberately not passed alongside `-s`. See the discussion below.

What is genuinely lost: source-level debugging with delve on a live process, `go tool nm`,
and core dump analysis under gdb. For a controller that is reached over the network and
observed through its logs and its pprof endpoint, none of those is how anyone works on it.

I would not sell this as hardening. `-s` does not meaningfully impede reverse
engineering; it is a size change.

### -trimpath

Almost free in size (0.2 MB) but worth its own line. It keeps the build machine's path out
of the binary, which today is **4470 occurrences** of a build directory in the
`linux/amd64` build, and it is one of the conditions for two builds of the same commit to
produce the same bytes.

### Verified

The `-X` version stamping still applies with `-s` in the same `-ldflags` string, checked
on a build carrying both.
