### PR TITLE
BUG/MINOR: main: exit with non-zero code on panic

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ func main() {
 	defer func() {
 		if r := recover(); r != nil {
 			fmt.Println("Error : ", r)
+			exitCode = 1
 		}
 		os.Exit(exitCode)
 	}()


### PR DESCRIPTION
When the controller runs in external mode and the Kubernetes API is unreachable at startup, `k8s.New` ends up in `logger.Panicf`. The deferred recover in main prints the error but `exitCode` is still 0 at that point, so the process exits successfully. Under systemd with `Restart=on-failure` the unit is considered cleanly stopped and is never restarted, leaving the ingress controller down until someone notices.

Set `exitCode` to 1 in the recover branch so a panic still prints the same message but reports failure to the init system.

Fixes #834
