### PR TITLE
Add --namespace-label-selector for dynamic namespace watching

### DIFF
--- a/deploy/tests/e2e/namespace-selector/config/deploy.yaml
+++ b/deploy/tests/e2e/namespace-selector/config/deploy.yaml
@@ -1,0 +1,35 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: http-echo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: http-echo
+  template:
+    metadata:
+      labels:
+        app: http-echo
+    spec:
+      containers:
+        - name: http-echo
+          image: haproxytech/http-echo:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8888
+              protocol: TCP
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: http-echo
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+  selector:
+    app: http-echo

--- a/deploy/tests/e2e/namespace-selector/config/ingress.yaml.tmpl
+++ b/deploy/tests/e2e/namespace-selector/config/ingress.yaml.tmpl
@@ -1,0 +1,18 @@
+---
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: http-echo
+spec:
+  ingressClassName: haproxy
+  rules:
+    - host: {{ .Host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: http-echo
+                port:
+                  name: http

--- a/deploy/tests/e2e/namespace-selector/config/late-tcp.yaml.tmpl
+++ b/deploy/tests/e2e/namespace-selector/config/late-tcp.yaml.tmpl
@@ -1,0 +1,16 @@
+apiVersion: ingress.v1.haproxy.org/v1
+kind: TCP
+metadata:
+  name: namespace-selector-late-tcp
+  annotations:
+    ingress.class: haproxy
+spec:
+  - name: {{ .Namespace }}-late-http
+    frontend:
+      name: {{ .Namespace }}-late-http
+      binds:
+        - name: v4
+          port: {{ .Port }}
+    service:
+      name: http-echo
+      port: 80

--- a/deploy/tests/e2e/namespace-selector/config/tcp.yaml
+++ b/deploy/tests/e2e/namespace-selector/config/tcp.yaml
@@ -1,0 +1,17 @@
+apiVersion: ingress.v3.haproxy.org/v3
+kind: TCP
+metadata:
+  name: namespace-selector-tcp
+  annotations:
+    ingress.class: haproxy
+spec:
+  - name: namespace-selector-http
+    frontend:
+      name: namespace-selector-http
+      binds:
+        v4:
+          name: v4
+          port: 32766
+    service:
+      name: http-echo
+      port: 80

--- a/deploy/tests/e2e/namespace-selector/namespace_selector_test.go
+++ b/deploy/tests/e2e/namespace-selector/namespace_selector_test.go
@@ -105,6 +105,8 @@ func (suite *NamespaceSelectorSuite) Test_UnlabelMutationRelabelUsesLatestIngres
 
 func (suite *NamespaceSelectorSuite) Test_TCPCRLabelUnlabelBounce() {
 	suite.Require().NoError(suite.test.Apply("config/tcp.yaml", suite.test.GetNS(), nil))
+	client, err := e2e.NewHTTPClient(suite.host, 32766)
+	suite.Require().NoError(err)
 	suite.T().Cleanup(func() {
 		out, err := kubectl(
 			"-n", suite.test.GetNS(),
@@ -112,9 +114,13 @@ func (suite *NamespaceSelectorSuite) Test_TCPCRLabelUnlabelBounce() {
 			"--ignore-not-found=true",
 		)
 		suite.Require().NoError(err, out)
+		suite.waitUnavailable(client)
+		suite.waitNoTCPFrontends()
+		// The Ingress backend is shared with the TCP CR. Wait until HTTP is
+		// restored while this namespace is still selected, otherwise the next
+		// test sees EOF/500 from a leftover TCP-mode backend.
+		suite.waitStatus(suite.client, 200)
 	})
-	client, err := e2e.NewHTTPClient(suite.host, 32766)
-	suite.Require().NoError(err)
 
 	suite.Require().NoError(labelNS(suite.test.GetNS(), "app=watch"))
 	suite.waitStatus(client, 200)

--- a/deploy/tests/e2e/namespace-selector/namespace_selector_test.go
+++ b/deploy/tests/e2e/namespace-selector/namespace_selector_test.go
@@ -1,0 +1,189 @@
+// Copyright 2019 HAProxy Technologies LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e_sequential
+
+package namespaceselector
+
+import (
+	"strings"
+
+	"github.com/haproxytech/kubernetes-ingress/deploy/tests/e2e"
+)
+
+func (suite *NamespaceSelectorSuite) Test_UnlabeledAtStart_Is404() {
+	suite.waitStatus(suite.client, 404)
+	suite.waitStatus(suite.foreignClient, 404)
+}
+
+func (suite *NamespaceSelectorSuite) Test_LabelStartsWatchWithoutTouchingIngress() {
+	suite.Require().NoError(labelNS(suite.test.GetNS(), "app=watch"))
+	suite.waitStatus(suite.client, 200)
+	suite.waitStatus(suite.foreignClient, 404)
+}
+
+func (suite *NamespaceSelectorSuite) Test_TwoMatchingNamespaces() {
+	suite.Require().NoError(labelNS(suite.test.GetNS(), "app=watch"))
+	suite.Require().NoError(labelNS(suite.foreignNS, "app=watch"))
+	suite.waitStatus(suite.client, 200)
+	suite.waitStatus(suite.foreignClient, 200)
+}
+
+func (suite *NamespaceSelectorSuite) Test_PrelabeledNamespacesBootstrapTogether() {
+	suite.Require().NoError(labelNS(suite.test.GetNS(), "app=watch"))
+	suite.Require().NoError(labelNS(suite.foreignNS, "app=watch"))
+	suite.Require().NoError(restartController())
+	suite.waitStatus(suite.client, 200)
+	suite.waitStatus(suite.foreignClient, 200)
+}
+
+func (suite *NamespaceSelectorSuite) Test_UnlabelDropsRouteAndConfig() {
+	suite.Require().NoError(labelNS(suite.test.GetNS(), "app=watch"))
+	suite.waitStatus(suite.client, 200)
+
+	suite.Require().NoError(labelNS(suite.test.GetNS(), "app-"))
+	suite.waitStatus(suite.client, 404)
+
+	cfg, err := suite.test.GetIngressControllerFile("/etc/haproxy/haproxy.cfg")
+	suite.Require().NoError(err)
+	suite.NotContains(cfg, suite.host)
+}
+
+func (suite *NamespaceSelectorSuite) Test_LabelValueChangeDropsRoute() {
+	suite.Require().NoError(labelNS(suite.test.GetNS(), "app=watch"))
+	suite.waitStatus(suite.client, 200)
+	suite.Require().NoError(labelNS(suite.test.GetNS(), "app=nowatch"))
+	suite.waitStatus(suite.client, 404)
+}
+
+func (suite *NamespaceSelectorSuite) Test_BounceRelabelRestoresWithoutIngressEdit() {
+	suite.Require().NoError(labelNS(suite.test.GetNS(), "app=watch"))
+	suite.waitStatus(suite.client, 200)
+	suite.Require().NoError(labelNS(suite.test.GetNS(), "app-"))
+	suite.waitStatus(suite.client, 404)
+	suite.Require().NoError(labelNS(suite.test.GetNS(), "app=watch"))
+	suite.waitStatus(suite.client, 200)
+}
+
+func (suite *NamespaceSelectorSuite) Test_UnlabelMutationRelabelUsesLatestIngress() {
+	suite.Require().NoError(labelNS(suite.test.GetNS(), "app=watch"))
+	suite.waitStatus(suite.client, 200)
+	suite.Require().NoError(labelNS(suite.test.GetNS(), "app-"))
+	suite.waitStatus(suite.client, 404)
+
+	updatedHost := "updated-" + suite.host
+	updatedClient, err := e2e.NewHTTPClient(updatedHost)
+	suite.Require().NoError(err)
+	suite.Require().NoError(suite.test.Apply(
+		"config/ingress.yaml.tmpl",
+		suite.test.GetNS(),
+		struct{ Host string }{Host: updatedHost},
+	))
+	suite.T().Cleanup(func() {
+		suite.Require().NoError(suite.test.Apply(
+			"config/ingress.yaml.tmpl",
+			suite.test.GetNS(),
+			struct{ Host string }{Host: suite.host},
+		))
+	})
+
+	suite.Require().NoError(labelNS(suite.test.GetNS(), "app=watch"))
+	suite.waitStatus(suite.client, 404)
+	suite.waitStatus(updatedClient, 200)
+}
+
+func (suite *NamespaceSelectorSuite) Test_TCPCRLabelUnlabelBounce() {
+	suite.Require().NoError(suite.test.Apply("config/tcp.yaml", suite.test.GetNS(), nil))
+	suite.T().Cleanup(func() {
+		out, err := kubectl(
+			"-n", suite.test.GetNS(),
+			"delete", "tcp", "namespace-selector-tcp",
+			"--ignore-not-found=true",
+		)
+		suite.Require().NoError(err, out)
+	})
+	client, err := e2e.NewHTTPClient(suite.host, 32766)
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(labelNS(suite.test.GetNS(), "app=watch"))
+	suite.waitStatus(client, 200)
+	suite.Require().NoError(labelNS(suite.test.GetNS(), "app-"))
+	suite.waitUnavailable(client)
+	suite.Require().NoError(labelNS(suite.test.GetNS(), "app=watch"))
+	suite.waitStatus(client, 200)
+}
+
+func (suite *NamespaceSelectorSuite) Test_DeletedNamespaceDropsRoute() {
+	namespace := suite.test.GetNS() + "-deleted"
+	out, err := kubectl("create", "ns", namespace)
+	suite.Require().NoError(err, out)
+	suite.T().Cleanup(func() {
+		out, err := kubectl("delete", "ns", namespace, "--ignore-not-found=true", "--wait=false")
+		suite.Require().NoError(err, out)
+	})
+	host := namespace + ".watch.test"
+	client, err := e2e.NewHTTPClient(host)
+	suite.Require().NoError(err)
+	suite.Require().NoError(suite.test.Apply("config/deploy.yaml", namespace, nil))
+	suite.Require().NoError(suite.test.Apply(
+		"config/ingress.yaml.tmpl",
+		namespace,
+		struct{ Host string }{Host: host},
+	))
+	suite.Require().NoError(labelNS(namespace, "app=watch"))
+	suite.waitStatus(client, 200)
+
+	out, err = kubectl("delete", "ns", namespace, "--wait=true", "--timeout=120s")
+	suite.Require().NoError(err, out)
+	suite.waitStatus(client, 404)
+	cfg, err := suite.test.GetIngressControllerFile("/etc/haproxy/haproxy.cfg")
+	suite.Require().NoError(err)
+	suite.NotContains(cfg, host)
+}
+
+func (suite *NamespaceSelectorSuite) Test_WhitelistPlusSelectorKeepsWhitelist() {
+	patched := append([]string{}, suite.originalArgs...)
+	patched = append(patched, "--namespace-whitelist="+suite.test.GetNS(), selectorFlag)
+	suite.Require().NoError(restoreControllerArgs(patched))
+	suite.T().Cleanup(func() {
+		suite.Require().NoError(restoreControllerArgs(suite.originalArgs))
+		suite.Require().NoError(setControllerSelector())
+		suite.Require().NoError(waitControllerRollout())
+	})
+	// The namespace is deliberately unlabeled. Whitelist must take precedence.
+	suite.waitStatus(suite.client, 200)
+	suite.Require().NoError(labelNS(suite.foreignNS, "app=watch"))
+	suite.waitStatus(suite.foreignClient, 404)
+	logs, err := kubectl("-n", controllerNS, "logs", "deploy/"+controllerName, "--tail=200")
+	suite.Require().NoError(err)
+	suite.True(strings.Contains(logs, "--namespace-label-selector is ignored"), logs)
+}
+
+func (suite *NamespaceSelectorSuite) Test_BlacklistPlusSelectorKeepsBlacklist() {
+	patched := append([]string{}, suite.originalArgs...)
+	patched = append(patched, "--namespace-blacklist="+suite.foreignNS, selectorFlag)
+	suite.Require().NoError(restoreControllerArgs(patched))
+	suite.T().Cleanup(func() {
+		suite.Require().NoError(restoreControllerArgs(suite.originalArgs))
+		suite.Require().NoError(setControllerSelector())
+		suite.Require().NoError(waitControllerRollout())
+	})
+	// Selector is ignored: the unlabeled, non-blacklisted namespace is watched.
+	suite.waitStatus(suite.client, 200)
+	suite.Require().NoError(labelNS(suite.foreignNS, "app=watch"))
+	suite.waitStatus(suite.foreignClient, 404)
+	logs, err := kubectl("-n", controllerNS, "logs", "deploy/"+controllerName, "--tail=200")
+	suite.Require().NoError(err)
+	suite.True(strings.Contains(logs, "--namespace-label-selector is ignored"), logs)
+}

--- a/deploy/tests/e2e/namespace-selector/session_regression_test.go
+++ b/deploy/tests/e2e/namespace-selector/session_regression_test.go
@@ -1,0 +1,217 @@
+// Copyright 2026 HAProxy Technologies LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e_sequential
+
+package namespaceselector
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/haproxytech/kubernetes-ingress/deploy/tests/e2e"
+)
+
+// These tests exercise real API/watch traffic, not a prescribed interleaving
+// between READY, shutdown, bootstrap snapshots and CRD registration. The narrow
+// races need deterministic unit tests as well.
+func (suite *NamespaceSelectorSuite) Test_RapidSelectionChurnDoesNotRestartController() {
+	suite.cleanupSelection()
+	suite.Require().NoError(labelNS(suite.foreignNS, "app=watch"))
+	suite.waitStatus(suite.foreignClient, 200)
+	suite.waitStatus(suite.client, 404)
+	before := suite.waitControllerSnapshot()
+
+	for round := 0; round < 3; round++ {
+		suite.churnSelection(4)
+		suite.waitStatus(suite.client, 200)
+		suite.waitStatus(suite.foreignClient, 200)
+		suite.Require().NoError(clearWatchLabel(suite.test.GetNS()))
+		suite.waitStatus(suite.client, 404)
+		suite.waitStatus(suite.foreignClient, 200)
+		suite.Equal(before, suite.waitControllerSnapshot(), "selection churn must not replace or restart the controller")
+	}
+	suite.Require().NoError(labelNS(suite.test.GetNS(), "app=watch"))
+	suite.waitStatus(suite.client, 200)
+	suite.Equal(before, suite.waitControllerSnapshot())
+}
+
+func (suite *NamespaceSelectorSuite) Test_BootstrapMembershipChurnRelabelRecovers() {
+	suite.cleanupSelection()
+	suite.Require().NoError(labelNS(suite.test.GetNS(), "app=watch"))
+	suite.Require().NoError(labelNS(suite.foreignNS, "app=watch"))
+	suite.waitStatus(suite.client, 200)
+	suite.waitStatus(suite.foreignClient, 200)
+	before := suite.waitControllerSnapshot()
+
+	// Do not wait for rollout before changing membership. API scheduling may
+	// still coalesce these events; this is bootstrap stress, not a race proof.
+	out, err := kubectl("-n", controllerNS, "rollout", "restart", "deploy/"+controllerName)
+	suite.Require().NoError(err, out)
+	suite.churnSelection(12)
+	suite.Require().NoError(clearWatchLabel(suite.test.GetNS()))
+	suite.Require().NoError(waitControllerRollout())
+	suite.waitStatus(suite.client, 404)
+	suite.waitStatus(suite.foreignClient, 200)
+	after := suite.waitControllerSnapshot()
+	suite.NotEqual(before.UID, after.UID, "bootstrap must run in a new pod")
+	suite.Zero(after.Restarts, "the intentionally replaced controller must not crash during bootstrap")
+
+	// Relabel without touching the Ingress: a stale bootstrap session must not
+	// suppress a fresh LIST/READY and strand this namespace as irrelevant.
+	suite.Require().NoError(labelNS(suite.test.GetNS(), "app=watch"))
+	suite.waitStatus(suite.client, 200)
+	suite.Require().NoError(clearWatchLabel(suite.foreignNS))
+	suite.waitStatus(suite.foreignClient, 404)
+	suite.waitStatus(suite.client, 200)
+	suite.Require().NoError(labelNS(suite.foreignNS, "app=watch"))
+	suite.waitStatus(suite.foreignClient, 200)
+	suite.Equal(after, suite.waitControllerSnapshot())
+}
+
+func (suite *NamespaceSelectorSuite) Test_LateTCPCRDWithSelectionChurn() {
+	if os.Getenv("NAMESPACE_SELECTOR_ISOLATED_CRD_TEST") != "1" {
+		suite.T().Skip("requires explicit NAMESPACE_SELECTOR_ISOLATED_CRD_TEST=1 on a disposable, exclusively owned cluster")
+	}
+	const crd = "tcps.ingress.v1.haproxy.org"
+	out, err := kubectl("get", "crd", crd, "--ignore-not-found", "-o", "name")
+	suite.Require().NoError(err, out)
+	if out != "" {
+		suite.T().Skip("late CRD test requires v1 TCP CRD absent; never deletes a pre-existing CRD")
+	}
+	suite.cleanupSelection()
+	suite.Require().NoError(labelNS(suite.foreignNS, "app=watch"))
+	suite.waitStatus(suite.foreignClient, 200)
+	before := suite.waitControllerSnapshot()
+
+	// create (not apply) prevents taking ownership of an existing definition.
+	out, err = kubectl("create", "-f", "../../../../crs/definition/ingress.v1.haproxy.org_tcps.yaml")
+	suite.Require().NoError(err, out)
+	suite.T().Cleanup(func() {
+		// Only this test owns this definition and its instances. Delete the
+		// objects first so a leftover TCP frontend cannot poison later HTTP
+		// tests. Restart after CRD removal because CRD deletion is not monitored.
+		for _, ns := range []string{suite.test.GetNS(), suite.foreignNS} {
+			out, err := kubectl("-n", ns, "delete", "tcp.ingress.v1.haproxy.org", "namespace-selector-late-tcp", "--ignore-not-found=true")
+			suite.NoError(err, out)
+		}
+		out, err := kubectl("delete", "crd", crd, "--ignore-not-found", "--timeout=120s")
+		suite.NoError(err, out)
+		suite.NoError(restartController())
+		suite.waitNoTCPFrontends()
+	})
+	out, err = kubectl("wait", "--for=condition=Established", "crd/"+crd, "--timeout=60s")
+	suite.Require().NoError(err, out)
+
+	for _, fixture := range []struct {
+		Namespace string
+		Port      int
+	}{
+		{suite.test.GetNS(), 32766},
+		{suite.foreignNS, 32767},
+	} {
+		suite.Require().NoError(suite.test.Apply("config/late-tcp.yaml.tmpl", fixture.Namespace, fixture))
+	}
+	client, err := e2e.NewHTTPClient(suite.host, 32766)
+	suite.Require().NoError(err)
+	foreignClient, err := e2e.NewHTTPClient(suite.foreignHost, 32767)
+	suite.Require().NoError(err)
+	// Keep churning while the existing, healthy session discovers the new
+	// CRD. Do not rely on a sleep matching the controller's discovery delay.
+	suite.Require().Eventually(func() bool {
+		for _, label := range []string{"app=watch", "app-", "app=watch"} {
+			if err := labelNS(suite.test.GetNS(), label); err != nil {
+				suite.T().Log(err)
+				return false
+			}
+		}
+		response, closeResponse, err := foreignClient.Do()
+		if closeResponse != nil {
+			defer closeResponse()
+		}
+		return err == nil && response.StatusCode == 200
+	}, e2e.WaitDuration, e2e.TickDuration)
+	suite.waitStatus(client, 200)
+	suite.waitStatus(foreignClient, 200)
+
+	suite.Require().NoError(clearWatchLabel(suite.test.GetNS()))
+	suite.waitUnavailable(client)
+	suite.waitStatus(foreignClient, 200)
+	suite.Require().NoError(labelNS(suite.test.GetNS(), "app=watch"))
+	suite.waitStatus(client, 200)
+	suite.waitStatus(foreignClient, 200)
+	suite.Equal(before, suite.waitControllerSnapshot(), "late CRD and selection churn must not restart the controller")
+}
+
+func (suite *NamespaceSelectorSuite) cleanupSelection() {
+	suite.T().Cleanup(func() {
+		suite.NoError(clearWatchLabel(suite.test.GetNS()))
+		suite.NoError(clearWatchLabel(suite.foreignNS))
+	})
+}
+
+func (suite *NamespaceSelectorSuite) churnSelection(cycles int) {
+	for i := 0; i < cycles; i++ {
+		suite.Require().NoError(labelNS(suite.test.GetNS(), "app=watch"))
+		suite.Require().NoError(clearWatchLabel(suite.test.GetNS()))
+		suite.Require().NoError(labelNS(suite.test.GetNS(), "app=watch"))
+	}
+}
+
+type controllerSnapshot struct {
+	UID      string
+	Restarts int32
+}
+
+func (suite *NamespaceSelectorSuite) waitControllerSnapshot() controllerSnapshot {
+	var snapshot controllerSnapshot
+	suite.Require().Eventually(func() bool {
+		var err error
+		snapshot, err = readControllerSnapshot()
+		if err != nil {
+			suite.T().Log(err)
+		}
+		return err == nil
+	}, e2e.WaitDuration, e2e.TickDuration)
+	return snapshot
+}
+
+func readControllerSnapshot() (controllerSnapshot, error) {
+	out, err := kubectl("-n", controllerNS, "get", "pods", "-l", "run=haproxy-ingress", "-o", "json")
+	if err != nil {
+		return controllerSnapshot{}, fmt.Errorf("get controller pods: %w: %s", err, out)
+	}
+	var pods corev1.PodList
+	if err := json.Unmarshal([]byte(out), &pods); err != nil {
+		return controllerSnapshot{}, err
+	}
+	// This suite uses the single-replica deployment in deploy/tests/config.
+	// Requiring one pod also avoids hiding a rolling replacement in the sample.
+	if len(pods.Items) != 1 {
+		return controllerSnapshot{}, fmt.Errorf("expected one controller pod, got %d", len(pods.Items))
+	}
+	pod := pods.Items[0]
+	if pod.DeletionTimestamp != nil {
+		return controllerSnapshot{}, fmt.Errorf("controller pod %s is terminating", pod.Name)
+	}
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.Name == "haproxy-ingress" && status.Ready && status.State.Running != nil {
+			return controllerSnapshot{UID: string(pod.UID), Restarts: status.RestartCount}, nil
+		}
+	}
+	return controllerSnapshot{}, fmt.Errorf("controller pod %s is not ready", pod.Name)
+}

--- a/deploy/tests/e2e/namespace-selector/suite_test.go
+++ b/deploy/tests/e2e/namespace-selector/suite_test.go
@@ -98,6 +98,8 @@ func (suite *NamespaceSelectorSuite) SetupSuite() {
 func (suite *NamespaceSelectorSuite) SetupTest() {
 	suite.Require().NoError(clearWatchLabel(suite.test.GetNS()))
 	suite.Require().NoError(clearWatchLabel(suite.foreignNS))
+	suite.waitStatus(suite.client, 404)
+	suite.waitStatus(suite.foreignClient, 404)
 }
 
 func (suite *NamespaceSelectorSuite) TearDownSuite() {
@@ -113,6 +115,17 @@ func (suite *NamespaceSelectorSuite) waitStatus(client *e2e.Client, want int) {
 		}
 		defer cls()
 		return r.StatusCode == want
+	}, e2e.WaitDuration, e2e.TickDuration)
+}
+
+func (suite *NamespaceSelectorSuite) waitNoTCPFrontends() {
+	suite.Require().Eventually(func() bool {
+		cfg, err := suite.test.GetIngressControllerFile("/etc/haproxy/haproxy.cfg")
+		if err != nil {
+			suite.T().Log(err)
+			return false
+		}
+		return !strings.Contains(cfg, "frontend tcpcr_")
 	}, e2e.WaitDuration, e2e.TickDuration)
 }
 

--- a/deploy/tests/e2e/namespace-selector/suite_test.go
+++ b/deploy/tests/e2e/namespace-selector/suite_test.go
@@ -1,0 +1,212 @@
+// Copyright 2019 HAProxy Technologies LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e_sequential
+
+package namespaceselector
+
+import (
+	"encoding/json"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/haproxytech/kubernetes-ingress/deploy/tests/e2e"
+)
+
+const (
+	controllerNS   = "haproxy-controller"
+	controllerName = "haproxy-kubernetes-ingress"
+	selectorFlag   = "--namespace-label-selector=app=watch"
+)
+
+type NamespaceSelectorSuite struct {
+	suite.Suite
+	test          e2e.Test
+	client        *e2e.Client
+	foreignClient *e2e.Client
+	host          string
+	foreignHost   string
+	foreignNS     string
+	originalArgs  []string
+}
+
+func TestNamespaceSelectorSuite(t *testing.T) {
+	suite.Run(t, new(NamespaceSelectorSuite))
+}
+
+func (suite *NamespaceSelectorSuite) SetupSuite() {
+	var err error
+	suite.test, err = e2e.NewTest()
+	suite.Require().NoError(err)
+
+	suite.originalArgs, err = controllerArgs()
+	suite.Require().NoError(err)
+	suite.T().Cleanup(func() {
+		if err := restoreControllerArgs(suite.originalArgs); err != nil {
+			suite.T().Errorf("failed to restore controller args: %v", err)
+		}
+	})
+
+	// Default backend and controller ConfigMaps live in the controller
+	// namespace. Selector mode 503s unmatched hosts unless that namespace is
+	// selected.
+	suite.Require().NoError(labelNS(controllerNS, "app=watch"))
+	suite.T().Cleanup(func() {
+		if err := clearWatchLabel(controllerNS); err != nil {
+			suite.T().Errorf("failed to clear controller namespace label: %v", err)
+		}
+	})
+
+	suite.Require().NoError(setControllerSelector())
+	suite.Require().NoError(waitControllerRollout())
+
+	suite.host = suite.test.GetNS() + ".watch.test"
+	suite.client, err = e2e.NewHTTPClient(suite.host)
+	suite.Require().NoError(err)
+	suite.Require().NoError(suite.test.Apply("config/deploy.yaml", suite.test.GetNS(), nil))
+	suite.Require().NoError(suite.test.Apply("config/ingress.yaml.tmpl", suite.test.GetNS(), struct{ Host string }{Host: suite.host}))
+
+	suite.foreignNS = suite.test.GetNS() + "-foreign"
+	out, err := kubectl("create", "ns", suite.foreignNS)
+	suite.Require().NoError(err, out)
+	suite.test.AddTearDown(func() error {
+		_, delErr := kubectl("delete", "ns", suite.foreignNS, "--wait=false")
+		return delErr
+	})
+	suite.foreignHost = suite.foreignNS + ".watch.test"
+	suite.foreignClient, err = e2e.NewHTTPClient(suite.foreignHost)
+	suite.Require().NoError(err)
+	suite.Require().NoError(suite.test.Apply("config/deploy.yaml", suite.foreignNS, nil))
+	suite.Require().NoError(suite.test.Apply("config/ingress.yaml.tmpl", suite.foreignNS, struct{ Host string }{Host: suite.foreignHost}))
+}
+
+func (suite *NamespaceSelectorSuite) SetupTest() {
+	suite.Require().NoError(clearWatchLabel(suite.test.GetNS()))
+	suite.Require().NoError(clearWatchLabel(suite.foreignNS))
+}
+
+func (suite *NamespaceSelectorSuite) TearDownSuite() {
+	suite.Require().NoError(suite.test.TearDown())
+}
+
+func (suite *NamespaceSelectorSuite) waitStatus(client *e2e.Client, want int) {
+	suite.Require().Eventually(func() bool {
+		r, cls, err := client.Do()
+		if err != nil {
+			suite.T().Log(err)
+			return false
+		}
+		defer cls()
+		return r.StatusCode == want
+	}, e2e.WaitDuration, e2e.TickDuration)
+}
+
+func (suite *NamespaceSelectorSuite) waitUnavailable(client *e2e.Client) {
+	suite.Require().Eventually(func() bool {
+		_, cls, err := client.Do()
+		if err != nil {
+			return true
+		}
+		if cls != nil {
+			cls()
+		}
+		return false
+	}, e2e.WaitDuration, e2e.TickDuration)
+}
+
+func kubectl(args ...string) (string, error) {
+	cmd := exec.Command("kubectl", args...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func controllerArgs() ([]string, error) {
+	out, err := kubectl("-n", controllerNS, "get", "deploy", controllerName, "-o", "json")
+	if err != nil {
+		return nil, err
+	}
+	var deploy struct {
+		Spec struct {
+			Template struct {
+				Spec struct {
+					Containers []struct {
+						Args []string `json:"args"`
+					} `json:"containers"`
+				} `json:"spec"`
+			} `json:"template"`
+		} `json:"spec"`
+	}
+	if err := json.Unmarshal([]byte(out), &deploy); err != nil {
+		return nil, err
+	}
+	if len(deploy.Spec.Template.Spec.Containers) == 0 {
+		return nil, errors.New("controller deployment has no containers")
+	}
+	return deploy.Spec.Template.Spec.Containers[0].Args, nil
+}
+
+func restoreControllerArgs(args []string) error {
+	raw, err := json.Marshal(args)
+	if err != nil {
+		return err
+	}
+	patch := `[{"op":"replace","path":"/spec/template/spec/containers/0/args","value":` + string(raw) + `}]`
+	out, err := kubectl("-n", controllerNS, "patch", "deploy", controllerName, "--type=json", "-p", patch)
+	if err != nil {
+		return err
+	}
+	_ = out
+	return waitControllerRollout()
+}
+
+func setControllerSelector() error {
+	patch := `[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"` + selectorFlag + `"}]`
+	if _, err := kubectl("-n", controllerNS, "patch", "deploy", controllerName, "--type=json", "-p", patch); err != nil {
+		return err
+	}
+	return nil
+}
+
+func waitControllerRollout() error {
+	_, err := kubectl("-n", controllerNS, "rollout", "status", "deploy/"+controllerName, "--timeout=120s")
+	return err
+}
+
+func restartController() error {
+	if _, err := kubectl("-n", controllerNS, "rollout", "restart", "deploy/"+controllerName); err != nil {
+		return err
+	}
+	return waitControllerRollout()
+}
+
+func clearWatchLabel(name string) error {
+	out, err := kubectl("label", "ns", name, "app-")
+	if err != nil && (strings.Contains(out, "not found") || strings.Contains(out, "not labeled")) {
+		return nil
+	}
+	return err
+}
+
+func labelNS(name, label string) error {
+	out, err := kubectl("label", "ns", name, label, "--overwrite")
+	if err != nil {
+		return err
+	}
+	_ = out
+	return nil
+}

--- a/documentation/controller.md
+++ b/documentation/controller.md
@@ -25,6 +25,7 @@ Image can be run with arguments:
 | [`--gateway-controller-name`](#--gateway-controller-name) |  |
 | [`--namespace-blacklist`](#--namespace-blacklist) |  |
 | [`--namespace-whitelist`](#--namespace-whitelist) |  |
+| [`--namespace-label-selector`](#--namespace-label-selector) |  |
 | [`--publish-service`](#--publish-service) |  |
 | [`--disable-ipv4`](#--disable-ipv4) | `false` |
 | [`--disable-ipv6`](#--disable-ipv6) | `false` |
@@ -454,6 +455,24 @@ Example:
 
 ```yaml
 --namespace-whitelist=foo --namespace-whitelist=bar
+```
+
+<p align='right'><a href='#haproxy-kubernetes-ingress-controller'>:arrow_up_small: back to top</a></p>
+
+***
+
+### `--namespace-label-selector`
+
+  Kubernetes label selector of namespaces to watch. Only namespaces that currently match are watched. Labeling a namespace starts a watch; removing or changing the label so it no longer matches stops the watch and drops that namespace from the generated HAProxy configuration. Ignored if `--namespace-whitelist` or `--namespace-blacklist` is set. The controller namespace, publish-service namespace, and default certificate namespace are not selected automatically.
+
+Possible values:
+
+- A Kubernetes label selector, for example `app=watch` or `env in (prod,staging)`
+
+Example:
+
+```yaml
+--namespace-label-selector=app=watch
 ```
 
 <p align='right'><a href='#haproxy-kubernetes-ingress-controller'>:arrow_up_small: back to top</a></p>

--- a/documentation/doc.yaml
+++ b/documentation/doc.yaml
@@ -214,6 +214,22 @@ image_arguments:
     helm: |-
       helm install haproxy haproxytech/kubernetes-ingress \
         --set-string "controller.extraArgs={--namespace-whitelist=foo}"
+  - argument: --namespace-label-selector
+    description: >
+      Kubernetes label selector of namespaces to watch. Only namespaces that
+      currently match are watched. Labeling a namespace starts a watch;
+      removing or changing the label so it no longer matches stops the watch
+      and drops that namespace from the generated HAProxy configuration.
+      Ignored if --namespace-whitelist or --namespace-blacklist is set.
+      The controller namespace, publish-service namespace, and default
+      certificate namespace are not selected automatically.
+    values:
+      - A Kubernetes label selector, for example app=watch or env in (prod,staging)
+    version_min: "3.2"
+    example: --namespace-label-selector=app=watch
+    helm: |-
+      helm install haproxy haproxytech/kubernetes-ingress \
+        --set-string "controller.extraArgs={--namespace-label-selector=app=watch}"
   - argument: --publish-service
     description: Copies the ingress controller's IP address to the 'Address' field in all Ingress objects that the controller manages. This is useful for tools like external-dns, which use this information to create DNS records.
     values:

--- a/main.go
+++ b/main.go
@@ -68,6 +68,11 @@ func main() {
 		exitCode = 1
 		return
 	}
+	if err = osArgs.ValidateNamespaceLabelSelector(); err != nil {
+		fmt.Println(err)
+		exitCode = 1
+		return
+	}
 
 	// Set Logger
 	logger := utils.GetLogger()
@@ -166,26 +171,36 @@ func main() {
 		meta.GetMetaStore().ProcessedResourceVersion.SetTestMode()
 	}
 
+	if osArgs.NamespaceLabelSelectorIgnored() {
+		logger.Warning("--namespace-label-selector is ignored because --namespace-whitelist or --namespace-blacklist is set")
+	}
+
+	isGatewayAPIInstalled := k.IsGatewayAPIInstalled(osArgs.GatewayControllerName)
+	sessions := k.NewSessionManager(eventChan, isGatewayAPIInstalled)
+
 	c := controller.NewBuilder().
 		WithHaproxyCfgFile(haproxyConf).
 		WithEventChan(eventChan).
 		WithStore(s).
 		WithClientSet(k.GetClientset()).
 		WithRestClientSet(k.GetRestClientset()).
-		WithArgs(osArgs).Build()
-
-	isGatewayAPIInstalled := k.IsGatewayAPIInstalled(osArgs.GatewayControllerName)
+		WithArgs(osArgs).
+		WithNamespaceSessions(sessions).
+		Build()
 
 	c.SetGatewayAPIInstalled(isGatewayAPIInstalled)
 
-	go k.MonitorChanges(eventChan, stop, osArgs, isGatewayAPIInstalled)
 	go c.Start()
+	go k.MonitorChanges(eventChan, stop, osArgs, isGatewayAPIInstalled)
 	// Catch QUIT signals
 	signalC := make(chan os.Signal, 1)
 	signal.Notify(signalC, os.Interrupt, syscall.SIGTERM, syscall.SIGUSR1)
 	<-signalC
 	logger.Print("Graceful shutdown requested ....")
 	c.Stop()
+	if sessions != nil {
+		sessions.Close()
+	}
 	close(stop)
 	logger.Print("Graceful shutdown done, exiting")
 }

--- a/pkg/annotations/models.go
+++ b/pkg/annotations/models.go
@@ -92,7 +92,7 @@ func model(name, defaultNS string, crType int, k store.K8s, annotations ...map[s
 		crNS = defaultNS
 	}
 	ns, nsOk := k.Namespaces[crNS]
-	if !nsOk {
+	if !nsOk || k.SkipNamespaceInConfig(ns) {
 		return nil, fmt.Errorf("annotation %s: custom resource '%s/%s' does not exist, namespace not found", name, crNS, crName)
 	}
 	switch crType {

--- a/pkg/controller/builder.go
+++ b/pkg/controller/builder.go
@@ -66,6 +66,7 @@ type Builder struct {
 	haproxyCfgFile           []byte
 	haproxyEnv               env.Env
 	osArgs                   utils.OSArgs
+	sessions                 NamespaceSessions
 }
 
 var defaultEnv = env.Env{
@@ -155,6 +156,11 @@ func (builder *Builder) WithUpdateStatusManager(updateStatusManager status.Updat
 	return builder
 }
 
+func (builder *Builder) WithNamespaceSessions(sessions NamespaceSessions) *Builder {
+	builder.sessions = sessions
+	return builder
+}
+
 func (builder *Builder) Build() *HAProxyController {
 	if builder.haproxyCfgFile == nil {
 		logger.Panic(errors.New("no HAProxy Config file provided"))
@@ -210,6 +216,7 @@ func (builder *Builder) Build() *HAProxyController {
 		prometheusMetricsManager: metrics.New(),
 		PodIP:                    podIP,
 		Hostname:                 hostname,
+		sessions:                 builder.sessions,
 	}
 	haproxyController.processIngress = haproxyController.processIngressesDefaultImplementation
 	if builder.osArgs.Experimental.UseIngressMerge {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -69,6 +69,17 @@ type HAProxyController struct {
 	// deterministically selected to provide the frontends' default backend.
 	// Reset before each processIngress() run and consumed by setIngressDefaultBackend().
 	defaultBackend *store.Ingress
+	sessions       NamespaceSessions
+}
+
+// NamespaceSessions is the controller-side view of per-namespace watch
+// sessions. Nil when --namespace-label-selector is not active.
+type NamespaceSessions interface {
+	Start(namespace string) error
+	Stop(namespace string)
+	Accept(namespace string, epoch uint64) bool
+	MarkReady(namespace string, epoch uint64) bool
+	Close()
 }
 
 // Wrapping a Native-Client transaction and commit it.
@@ -384,6 +395,24 @@ func (c *HAProxyController) manageIngress(ing *store.Ingress) {
 }
 
 //revive:disable-next-line:cognitive-complexity
+func (c *HAProxyController) ingressesEligibleForMerge(service *store.Service) []*store.Ingress {
+	if service == nil {
+		return nil
+	}
+	ingressesOrderedList := c.store.IngressesByService[service.Namespace+"/"+service.Name]
+	if ingressesOrderedList == nil {
+		return nil
+	}
+	var out []*store.Ingress
+	for _, ing := range ingressesOrderedList.Items() {
+		if c.store.SkipIngressInConfig(ing) {
+			continue
+		}
+		out = append(out, ing)
+	}
+	return out
+}
+
 func (c *HAProxyController) processIngressesWithMerge() {
 	// Namespaces and services are walked by name for the same reason as in
 	// processIngressesDefaultImplementation: rules are created in processing order and
@@ -398,14 +427,13 @@ func (c *HAProxyController) processIngressesWithMerge() {
 	// so the established ingress has precedence there too. The two go together: reversing
 	// the set without reversing the merge would give precedence to the newest ingress.
 	for _, namespace := range sortedByKey(c.store.Namespaces) {
+		if c.store.SkipNamespaceInConfig(namespace) {
+			continue
+		}
 		c.store.SecretsProcessed = map[string]struct{}{}
 		// Iterate over services
 		for _, service := range sortedByKey(namespace.Services) {
-			ingressesOrderedList := c.store.IngressesByService[service.Namespace+"/"+service.Name]
-			if ingressesOrderedList == nil {
-				continue
-			}
-			ingresses := ingressesOrderedList.Items()
+			ingresses := c.ingressesEligibleForMerge(service)
 			if len(ingresses) == 0 {
 				continue
 			}

--- a/pkg/controller/monitor.go
+++ b/pkg/controller/monitor.go
@@ -38,6 +38,8 @@ func (c *HAProxyController) SyncData() {
 		ns := c.store.GetNamespace(job.Namespace)
 		change := false
 		switch job.SyncType {
+		case k8ssync.BARRIER:
+			// Acknowledge prior store events without generating configuration.
 		case k8ssync.COMMAND:
 			c.auxCfgManager()
 			// create a NeedAction function.
@@ -86,10 +88,10 @@ func (c *HAProxyController) SyncData() {
 				case store.DELETED:
 					c.sessions.Stop(nsData.Name)
 				case store.ADDED:
-					if !job.IsInInitialList {
-						if err := c.sessions.Start(nsData.Name); err != nil {
-							logger.Panic(err)
-						}
+					// Initial and runtime membership share this queue so DELETE
+					// cannot be overtaken by a stale bootstrap snapshot.
+					if err := c.sessions.Start(nsData.Name); err != nil {
+						logger.Panic(err)
 					}
 				}
 			}

--- a/pkg/controller/monitor.go
+++ b/pkg/controller/monitor.go
@@ -28,6 +28,13 @@ import (
 func (c *HAProxyController) SyncData() {
 	hadChanges := false
 	for job := range c.eventChan {
+		if c.sessions != nil && k8ssync.IsNamespacedSessionEvent(job.SyncType) &&
+			!c.sessions.Accept(job.Namespace, job.NamespaceEpoch) {
+			if job.EventProcessed != nil {
+				close(job.EventProcessed)
+			}
+			continue
+		}
 		ns := c.store.GetNamespace(job.Namespace)
 		change := false
 		switch job.SyncType {
@@ -72,7 +79,30 @@ func (c *HAProxyController) SyncData() {
 			change = c.store.EventFrontendCR(job.Namespace, job.Name, data)
 		case k8ssync.NAMESPACE:
 			//revive:disable-next-line:unchecked-type-assertion
-			change = c.store.EventNamespace(ns, job.Data.(*store.Namespace))
+			nsData := job.Data.(*store.Namespace)
+			change = c.store.EventNamespace(ns, nsData)
+			if c.sessions != nil {
+				switch nsData.Status {
+				case store.DELETED:
+					c.sessions.Stop(nsData.Name)
+				case store.ADDED:
+					if !job.IsInInitialList {
+						if err := c.sessions.Start(nsData.Name); err != nil {
+							logger.Panic(err)
+						}
+					}
+				}
+			}
+		case k8ssync.NAMESPACE_SESSION_READY:
+			if c.sessions != nil && !c.sessions.MarkReady(job.Namespace, job.NamespaceEpoch) {
+				break
+			}
+			change = c.store.MarkNamespaceReady(job.Namespace)
+			hadChanges = hadChanges || change
+			if job.EventProcessed != nil {
+				close(job.EventProcessed)
+			}
+			continue
 		case k8ssync.INGRESS:
 			//revive:disable-next-line:unchecked-type-assertion
 			change = c.store.EventIngress(ns, job.Data.(*store.Ingress), job.UID, job.ResourceVersion)

--- a/pkg/controller/sync_namespace_selector_test.go
+++ b/pkg/controller/sync_namespace_selector_test.go
@@ -1,0 +1,201 @@
+// Copyright 2019 HAProxy Technologies LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	k8ssync "github.com/haproxytech/kubernetes-ingress/pkg/k8s/sync"
+	"github.com/haproxytech/kubernetes-ingress/pkg/store"
+	"github.com/haproxytech/kubernetes-ingress/pkg/utils"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type mockSessions struct {
+	starts []string
+	stops  []string
+	accept map[uint64]bool
+	allow  bool
+}
+
+func (m *mockSessions) Start(namespace string) error {
+	m.starts = append(m.starts, namespace)
+	return nil
+}
+func (m *mockSessions) Stop(namespace string) { m.stops = append(m.stops, namespace) }
+func (m *mockSessions) Accept(_ string, epoch uint64) bool {
+	if m.accept != nil {
+		if v, ok := m.accept[epoch]; ok {
+			return v
+		}
+	}
+	return m.allow
+}
+func (m *mockSessions) MarkReady(string, uint64) bool { return true }
+func (m *mockSessions) Close()                        {}
+
+func waitProcessed(t *testing.T, ch chan k8ssync.SyncDataEvent, ev k8ssync.SyncDataEvent) {
+	t.Helper()
+	done := make(chan struct{})
+	ev.EventProcessed = done
+	ch <- ev
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("event was not processed")
+	}
+}
+
+func TestSyncDataRejectsStaleEpoch(t *testing.T) {
+	st := store.NewK8sStore(utils.OSArgs{NamespaceLabelSelector: "watch=true"})
+	st.EventNamespace(nil, &store.Namespace{Name: "app", Status: store.ADDED})
+	st.MarkNamespaceReady("app")
+
+	ch := make(chan k8ssync.SyncDataEvent, 4)
+	mock := &mockSessions{accept: map[uint64]bool{1: false, 2: true}}
+	c := &HAProxyController{store: st, eventChan: ch, sessions: mock}
+	go c.SyncData()
+
+	ing := &store.Ingress{
+		IngressCore: store.IngressCore{
+			Namespace: "app",
+			Name:      "web",
+			Rules: map[string]*store.IngressRule{
+				"h": {Host: "h", Paths: map[string]*store.IngressPath{"/": {Path: "/", SvcNamespace: "app", SvcName: "svc"}}},
+			},
+		},
+		Status: store.ADDED,
+	}
+	waitProcessed(t, ch, k8ssync.SyncDataEvent{
+		SyncType: k8ssync.INGRESS, Namespace: "app", Data: ing, NamespaceEpoch: 1, UID: types.UID("1"), ResourceVersion: "1",
+	})
+	if st.Namespaces["app"].Ingresses["web"] != nil {
+		t.Fatal("stale epoch ingress must not be stored")
+	}
+
+	waitProcessed(t, ch, k8ssync.SyncDataEvent{
+		SyncType: k8ssync.INGRESS, Namespace: "app", Data: ing, NamespaceEpoch: 2, UID: types.UID("1"), ResourceVersion: "1",
+	})
+	if st.Namespaces["app"].Ingresses["web"] == nil {
+		t.Fatal("current epoch ingress must be stored")
+	}
+}
+
+func TestSyncDataDropsZeroEpochCRTCP(t *testing.T) {
+	st := store.NewK8sStore(utils.OSArgs{NamespaceLabelSelector: "watch=true"})
+	st.EventNamespace(nil, &store.Namespace{Name: "app", Status: store.ADDED})
+	st.MarkNamespaceReady("app")
+
+	ch := make(chan k8ssync.SyncDataEvent, 4)
+	mock := &mockSessions{accept: map[uint64]bool{0: false, 4: true}}
+	c := &HAProxyController{store: st, eventChan: ch, sessions: mock}
+	go c.SyncData()
+
+	tcp := &store.TCPs{Name: "tcp", Namespace: "app", Status: store.ADDED}
+	waitProcessed(t, ch, k8ssync.SyncDataEvent{
+		SyncType: k8ssync.CR_TCP, Namespace: "app", Name: "tcp", Data: tcp, NamespaceEpoch: 0,
+	})
+	if st.Namespaces["app"].CRs.TCPsPerCR["tcp"] != nil {
+		t.Fatal("late CR_TCP with epoch 0 must be dropped by Accept")
+	}
+
+	waitProcessed(t, ch, k8ssync.SyncDataEvent{
+		SyncType: k8ssync.CR_TCP, Namespace: "app", Name: "tcp", Data: tcp, NamespaceEpoch: 4,
+	})
+	if st.Namespaces["app"].CRs.TCPsPerCR["tcp"] == nil {
+		t.Fatal("CR_TCP with the session epoch must be stored")
+	}
+}
+
+func TestSyncDataStartsAndStopsSessions(t *testing.T) {
+	st := store.NewK8sStore(utils.OSArgs{NamespaceLabelSelector: "watch=true"})
+	ch := make(chan k8ssync.SyncDataEvent, 4)
+	mock := &mockSessions{allow: true}
+	c := &HAProxyController{store: st, eventChan: ch, sessions: mock}
+	go c.SyncData()
+
+	waitProcessed(t, ch, k8ssync.SyncDataEvent{
+		SyncType: k8ssync.NAMESPACE, Namespace: "app",
+		Data: &store.Namespace{Name: "app", Status: store.ADDED},
+	})
+	if len(mock.starts) != 1 || mock.starts[0] != "app" {
+		t.Fatalf("runtime ADD should Start session, got %v", mock.starts)
+	}
+
+	waitProcessed(t, ch, k8ssync.SyncDataEvent{
+		SyncType: k8ssync.NAMESPACE, Namespace: "app",
+		Data: &store.Namespace{Name: "app", Status: store.DELETED},
+	})
+	if len(mock.stops) != 1 {
+		t.Fatalf("DELETE should Stop session, got %v", mock.stops)
+	}
+	if _, ok := st.Namespaces["app"]; ok {
+		t.Fatal("selector DELETE should drop store namespace")
+	}
+}
+
+func TestSyncDataInitialListDoesNotStartSession(t *testing.T) {
+	st := store.NewK8sStore(utils.OSArgs{NamespaceLabelSelector: "watch=true"})
+	ch := make(chan k8ssync.SyncDataEvent, 4)
+	mock := &mockSessions{allow: true}
+	c := &HAProxyController{store: st, eventChan: ch, sessions: mock}
+	go c.SyncData()
+
+	waitProcessed(t, ch, k8ssync.SyncDataEvent{
+		SyncType: k8ssync.NAMESPACE, Namespace: "app", IsInInitialList: true,
+		Data: &store.Namespace{Name: "app", Status: store.ADDED},
+	})
+	if len(mock.starts) != 0 {
+		t.Fatalf("initial-list ADD must not Start, got %v", mock.starts)
+	}
+	if _, ok := st.NamespacesAccess.Selected["app"]; !ok {
+		t.Fatal("initial-list ADD must still select the namespace")
+	}
+}
+
+func TestIngressesEligibleForMergeSkipStartingNamespace(t *testing.T) {
+	st := store.NewK8sStore(utils.OSArgs{NamespaceLabelSelector: "watch=true"})
+	st.EventNamespace(nil, &store.Namespace{Name: "ready", Status: store.ADDED})
+	st.EventNamespace(nil, &store.Namespace{Name: "starting", Status: store.ADDED})
+	st.MarkNamespaceReady("ready")
+
+	readyIng := &store.Ingress{
+		IngressCore: store.IngressCore{
+			Namespace: "ready", Name: "ok",
+			Rules: map[string]*store.IngressRule{
+				"h": {Host: "ok", Paths: map[string]*store.IngressPath{"/": {Path: "/", SvcNamespace: "ready", SvcName: "svc"}}},
+			},
+		},
+		Status: store.ADDED,
+	}
+	foreign := &store.Ingress{
+		IngressCore: store.IngressCore{
+			Namespace: "starting", Name: "bad",
+			Rules: map[string]*store.IngressRule{
+				"h": {Host: "bad", Paths: map[string]*store.IngressPath{"/": {Path: "/", SvcNamespace: "ready", SvcName: "svc"}}},
+			},
+		},
+		Status: store.ADDED,
+	}
+	st.EventIngress(st.Namespaces["ready"], readyIng, types.UID("1"), "1")
+	st.EventIngress(st.Namespaces["starting"], foreign, types.UID("2"), "1")
+
+	c := &HAProxyController{store: st}
+	got := c.ingressesEligibleForMerge(&store.Service{Namespace: "ready", Name: "svc"})
+	if len(got) != 1 || got[0].Name != "ok" {
+		t.Fatalf("merge must keep only ready-ns ingresses, got %#v", got)
+	}
+}

--- a/pkg/controller/sync_namespace_selector_test.go
+++ b/pkg/controller/sync_namespace_selector_test.go
@@ -29,13 +29,18 @@ type mockSessions struct {
 	stops  []string
 	accept map[uint64]bool
 	allow  bool
+	calls  []string
 }
 
 func (m *mockSessions) Start(namespace string) error {
 	m.starts = append(m.starts, namespace)
+	m.calls = append(m.calls, "start:"+namespace)
 	return nil
 }
-func (m *mockSessions) Stop(namespace string) { m.stops = append(m.stops, namespace) }
+func (m *mockSessions) Stop(namespace string) {
+	m.stops = append(m.stops, namespace)
+	m.calls = append(m.calls, "stop:"+namespace)
+}
 func (m *mockSessions) Accept(_ string, epoch uint64) bool {
 	if m.accept != nil {
 		if v, ok := m.accept[epoch]; ok {
@@ -147,7 +152,7 @@ func TestSyncDataStartsAndStopsSessions(t *testing.T) {
 	}
 }
 
-func TestSyncDataInitialListDoesNotStartSession(t *testing.T) {
+func TestSyncDataInitialListStartsSession(t *testing.T) {
 	st := store.NewK8sStore(utils.OSArgs{NamespaceLabelSelector: "watch=true"})
 	ch := make(chan k8ssync.SyncDataEvent, 4)
 	mock := &mockSessions{allow: true}
@@ -158,11 +163,63 @@ func TestSyncDataInitialListDoesNotStartSession(t *testing.T) {
 		SyncType: k8ssync.NAMESPACE, Namespace: "app", IsInInitialList: true,
 		Data: &store.Namespace{Name: "app", Status: store.ADDED},
 	})
-	if len(mock.starts) != 0 {
-		t.Fatalf("initial-list ADD must not Start, got %v", mock.starts)
+	if len(mock.starts) != 1 || mock.starts[0] != "app" {
+		t.Fatalf("initial-list ADD must Start in the event queue, got %v", mock.starts)
 	}
 	if _, ok := st.NamespacesAccess.Selected["app"]; !ok {
 		t.Fatal("initial-list ADD must still select the namespace")
+	}
+}
+
+func TestSyncDataBootstrapDeleteAndRelabelAreOrdered(t *testing.T) {
+	st := store.NewK8sStore(utils.OSArgs{NamespaceLabelSelector: "watch=true"})
+	ch := make(chan k8ssync.SyncDataEvent, 6)
+	mock := &mockSessions{allow: true}
+	c := &HAProxyController{store: st, eventChan: ch, sessions: mock}
+
+	ch <- k8ssync.SyncDataEvent{
+		SyncType: k8ssync.NAMESPACE, Namespace: "app", IsInInitialList: true,
+		Data: &store.Namespace{Name: "app", Status: store.ADDED},
+	}
+	ch <- k8ssync.SyncDataEvent{
+		SyncType: k8ssync.NAMESPACE, Namespace: "app",
+		Data: &store.Namespace{Name: "app", Status: store.DELETED},
+	}
+	bootstrapDone := make(chan struct{})
+	ch <- k8ssync.SyncDataEvent{SyncType: k8ssync.BARRIER, EventProcessed: bootstrapDone}
+	close(ch)
+	// No HAProxy client is installed: a bootstrap barrier must not generate
+	// configuration, even though the namespace events marked the store dirty.
+	c.SyncData()
+	select {
+	case <-bootstrapDone:
+	default:
+		t.Fatal("bootstrap barrier was not acknowledged")
+	}
+	if len(mock.calls) != 2 || mock.calls[0] != "start:app" || mock.calls[1] != "stop:app" {
+		t.Fatalf("initial ADD and DELETE must execute in order, got %v", mock.calls)
+	}
+	if _, ok := st.NamespacesAccess.Selected["app"]; ok {
+		t.Fatal("deleted bootstrap namespace must not remain selected")
+	}
+	if _, ok := st.Namespaces["app"]; ok {
+		t.Fatal("deleted bootstrap namespace must not remain in the store")
+	}
+
+	ch = make(chan k8ssync.SyncDataEvent, 2)
+	c.eventChan = ch
+	ch <- k8ssync.SyncDataEvent{
+		SyncType: k8ssync.NAMESPACE, Namespace: "app",
+		Data: &store.Namespace{Name: "app", Status: store.ADDED},
+	}
+	ch <- k8ssync.SyncDataEvent{SyncType: k8ssync.NAMESPACE_SESSION_READY, Namespace: "app", NamespaceEpoch: 2}
+	close(ch)
+	c.SyncData()
+	if len(mock.calls) != 3 || mock.calls[2] != "start:app" {
+		t.Fatalf("relabel must start a fresh session, got %v", mock.calls)
+	}
+	if !st.Namespaces["app"].Relevant {
+		t.Fatal("relabelled namespace must become ready")
 	}
 }
 

--- a/pkg/handler/tcp-cr.go
+++ b/pkg/handler/tcp-cr.go
@@ -76,6 +76,9 @@ func (handler TCPCustomResource) Update(k store.K8s, h haproxy.HAProxy, a annota
 	var errs utils.Errors
 
 	for _, ns := range k.Namespaces {
+		if k.SkipNamespaceInConfig(ns) {
+			continue
+		}
 		for _, tcpCR := range ns.CRs.TCPsPerCR {
 			// ----------------------------------
 			// ingress.class migration

--- a/pkg/k8s/cr-backend.go
+++ b/pkg/k8s/cr-backend.go
@@ -36,7 +36,7 @@ func (c BackendCR) GetKind() string {
 	return "Backend"
 }
 
-func (c BackendCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factory informers.SharedInformerFactory, osArgs utils.OSArgs) cache.SharedIndexInformer { //nolint:ireturn
+func (c BackendCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factory informers.SharedInformerFactory, osArgs utils.OSArgs) (cache.SharedIndexInformer, cache.ResourceEventHandlerRegistration) { //nolint:ireturn
 	informer := factory.Ingress().V3().Backends().Informer()
 
 	sendToChannel := func(eventChan chan k8ssync.SyncDataEvent, object interface{}, status store.Status) {
@@ -63,7 +63,7 @@ func (c BackendCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factory i
 		go logger.Debug("Backend CR informer error: %s", err)
 	})
 	logger.Error(errW)
-	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	reg, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			sendToChannel(eventChan, obj, store.ADDED)
 		},
@@ -78,5 +78,5 @@ func (c BackendCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factory i
 	// Use TransformFunc to modify/filter objects before passing them to handlers
 	err = informer.SetTransform(k8stransform.TransformBackend)
 	logger.Error(err)
-	return informer
+	return informer, reg
 }

--- a/pkg/k8s/cr-defaults.go
+++ b/pkg/k8s/cr-defaults.go
@@ -34,7 +34,7 @@ func (c DefaultsCR) GetKind() string {
 	return "Defaults"
 }
 
-func (c DefaultsCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factory informersv3.SharedInformerFactory, osArgs utils.OSArgs) cache.SharedIndexInformer { //nolint:ireturn
+func (c DefaultsCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factory informersv3.SharedInformerFactory, osArgs utils.OSArgs) (cache.SharedIndexInformer, cache.ResourceEventHandlerRegistration) { //nolint:ireturn
 	informer := factory.Ingress().V3().Defaults().Informer()
 
 	sendToChannel := func(eventChan chan k8ssync.SyncDataEvent, object interface{}, status store.Status) {
@@ -61,7 +61,7 @@ func (c DefaultsCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factory 
 		go logger.Debug("Defaults CR informer error: %s", err)
 	})
 	logger.Error(errW)
-	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	reg, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			sendToChannel(eventChan, obj, store.ADDED)
 		},
@@ -73,5 +73,5 @@ func (c DefaultsCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factory 
 		},
 	})
 	logger.Error(err)
-	return informer
+	return informer, reg
 }

--- a/pkg/k8s/cr-frontend.go
+++ b/pkg/k8s/cr-frontend.go
@@ -36,7 +36,7 @@ func (c FrontendCR) GetKind() string {
 	return "Frontend"
 }
 
-func (c FrontendCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factory informers.SharedInformerFactory, osArgs utils.OSArgs) cache.SharedIndexInformer { //nolint:ireturn
+func (c FrontendCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factory informers.SharedInformerFactory, osArgs utils.OSArgs) (cache.SharedIndexInformer, cache.ResourceEventHandlerRegistration) { //nolint:ireturn
 	informer := factory.Ingress().V3().Frontends().Informer()
 
 	sendToChannel := func(eventChan chan k8ssync.SyncDataEvent, object interface{}, status store.Status) {
@@ -61,7 +61,7 @@ func (c FrontendCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factory 
 		go logger.Debug("Frontend CR informer error: %s", err)
 	})
 	logger.Error(errW)
-	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	reg, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			sendToChannel(eventChan, obj, store.ADDED)
 		},
@@ -76,5 +76,5 @@ func (c FrontendCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factory 
 	// Use TransformFunc to modify/filter objects before passing them to handlers
 	err = informer.SetTransform(k8stransform.TransformBackend)
 	logger.Error(err)
-	return informer
+	return informer, reg
 }

--- a/pkg/k8s/cr-global.go
+++ b/pkg/k8s/cr-global.go
@@ -34,7 +34,7 @@ func (c GlobalCR) GetKind() string {
 	return "Global"
 }
 
-func (c GlobalCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factory informersv3.SharedInformerFactory, osArgs utils.OSArgs) cache.SharedIndexInformer { //nolint:ireturn
+func (c GlobalCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factory informersv3.SharedInformerFactory, osArgs utils.OSArgs) (cache.SharedIndexInformer, cache.ResourceEventHandlerRegistration) { //nolint:ireturn
 	informer := factory.Ingress().V3().Globals().Informer()
 
 	sendToChannel := func(eventChan chan k8ssync.SyncDataEvent, object interface{}, status store.Status) {
@@ -61,7 +61,7 @@ func (c GlobalCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factory in
 		go logger.Debug("Global CR informer error: %s", err)
 	})
 	logger.Error(errW)
-	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	reg, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			sendToChannel(eventChan, obj, store.ADDED)
 		},
@@ -73,5 +73,5 @@ func (c GlobalCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factory in
 		},
 	})
 	logger.Error(err)
-	return informer
+	return informer, reg
 }

--- a/pkg/k8s/cr-tcp.go
+++ b/pkg/k8s/cr-tcp.go
@@ -73,6 +73,9 @@ func (c TCPCR) GetKind() string {
 }
 
 func convertToStoreTCP(k8sData interface{}, status store.Status) *store.TCPs {
+	if tombstone, ok := k8sData.(cache.DeletedFinalStateUnknown); ok {
+		k8sData = tombstone.Obj
+	}
 	data, ok := k8sData.(*v3.TCP)
 	if !ok {
 		logger.Warning(CRSGroupVersionV3 + ": type mismatch with TCP CR kind")

--- a/pkg/k8s/cr-tcp.go
+++ b/pkg/k8s/cr-tcp.go
@@ -29,7 +29,7 @@ func NewTCPCRV3() TCPCR {
 	return TCPCR{}
 }
 
-func (c TCPCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factory informersv3.SharedInformerFactory, osArgs utils.OSArgs) cache.SharedIndexInformer { //nolint:ireturn
+func (c TCPCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factory informersv3.SharedInformerFactory, osArgs utils.OSArgs) (cache.SharedIndexInformer, cache.ResourceEventHandlerRegistration) { //nolint:ireturn
 	informer := factory.Ingress().V3().TCPs().Informer()
 
 	sendToChannel := func(eventChan chan k8ssync.SyncDataEvent, newObject interface{}, status store.Status) {
@@ -53,7 +53,7 @@ func (c TCPCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factory infor
 		go logger.Debug("Global CR informer error: %s", err)
 	})
 	logger.Error(errW)
-	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	reg, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			sendToChannel(eventChan, obj, store.ADDED)
 		},
@@ -65,7 +65,7 @@ func (c TCPCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factory infor
 		},
 	})
 	logger.Error(err)
-	return informer
+	return informer, reg
 }
 
 func (c TCPCR) GetKind() string {

--- a/pkg/k8s/cr-tcp_test.go
+++ b/pkg/k8s/cr-tcp_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 HAProxy Technologies LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"testing"
+
+	v3 "github.com/haproxytech/kubernetes-ingress/crs/api/ingress/v3"
+	"github.com/haproxytech/kubernetes-ingress/pkg/store"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestConvertToStoreTCPTombstone(t *testing.T) {
+	t.Parallel()
+	tcp := &v3.TCP{
+		ObjectMeta: metav1.ObjectMeta{Name: "tcp", Namespace: "app"},
+		Spec:       v3.TCPSpec{{Name: "item"}},
+	}
+	got := convertToStoreTCP(cache.DeletedFinalStateUnknown{Obj: tcp}, store.DELETED)
+	if got == nil {
+		t.Fatal("tombstone TCP CR must convert")
+	}
+	if got.Name != "tcp" || got.Namespace != "app" || got.Status != store.DELETED {
+		t.Fatalf("tombstone identity: %+v", got)
+	}
+	if len(got.Items) != 1 || got.Items[0].Name != "item" {
+		t.Fatalf("tombstone items: %+v", got.Items)
+	}
+}

--- a/pkg/k8s/cr-validation-rules.go
+++ b/pkg/k8s/cr-validation-rules.go
@@ -30,7 +30,7 @@ func NewValidationCRV3() ValidationCR {
 	return ValidationCR{}
 }
 
-func (c ValidationCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factory informersv3.SharedInformerFactory, osArgs utils.OSArgs) cache.SharedIndexInformer { //nolint:ireturn
+func (c ValidationCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factory informersv3.SharedInformerFactory, osArgs utils.OSArgs) (cache.SharedIndexInformer, cache.ResourceEventHandlerRegistration) { //nolint:ireturn
 	informer := factory.Ingress().V3().ValidationRules().Informer()
 
 	sendToChannel := func(eventChan chan k8ssync.SyncDataEvent, newObject interface{}, status store.Status) {
@@ -78,7 +78,7 @@ func (c ValidationCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factor
 		go logger.Debug("ValidationRules CR informer error: %s", err)
 	})
 	logger.Error(errW)
-	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	reg, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			sendToChannel(eventChan, obj, store.ADDED)
 		},
@@ -90,7 +90,7 @@ func (c ValidationCR) GetInformerV3(eventChan chan k8ssync.SyncDataEvent, factor
 		},
 	})
 	logger.Error(err)
-	return informer
+	return informer, reg
 }
 
 func (c ValidationCR) GetKind() string {

--- a/pkg/k8s/crs-deprecated-v1.go
+++ b/pkg/k8s/crs-deprecated-v1.go
@@ -236,6 +236,9 @@ func (c TCPCRV1) GetInformerV1(eventChan chan k8ssync.SyncDataEvent, factory inf
 			sendToChannel(eventChan, newObj, store.MODIFIED)
 		},
 		DeleteFunc: func(obj interface{}) {
+			if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				obj = tombstone.Obj
+			}
 			sendToChannel(eventChan, obj, store.DELETED)
 		},
 	})

--- a/pkg/k8s/crs-deprecated-v1.go
+++ b/pkg/k8s/crs-deprecated-v1.go
@@ -53,7 +53,7 @@ func (c GlobalCRV1) GetKind() string {
 	return "Global"
 }
 
-func (c GlobalCRV1) GetInformerV1(eventChan chan k8ssync.SyncDataEvent, factory informersv1.SharedInformerFactory) cache.SharedIndexInformer { //nolint:ireturn
+func (c GlobalCRV1) GetInformerV1(eventChan chan k8ssync.SyncDataEvent, factory informersv1.SharedInformerFactory) (cache.SharedIndexInformer, cache.ResourceEventHandlerRegistration) { //nolint:ireturn
 	informer := factory.Ingress().V1().Globals().Informer()
 
 	sendToChannel := func(eventChan chan k8ssync.SyncDataEvent, object interface{}, status store.Status) {
@@ -84,7 +84,7 @@ func (c GlobalCRV1) GetInformerV1(eventChan chan k8ssync.SyncDataEvent, factory 
 		}
 	}
 
-	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	reg, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			sendToChannel(eventChan, obj, store.ADDED)
 		},
@@ -96,14 +96,14 @@ func (c GlobalCRV1) GetInformerV1(eventChan chan k8ssync.SyncDataEvent, factory 
 		},
 	})
 	logger.Error(err)
-	return informer
+	return informer, reg
 }
 
 func (c DefaultsCRV1) GetKind() string {
 	return "Defaults"
 }
 
-func (c DefaultsCRV1) GetInformerV1(eventChan chan k8ssync.SyncDataEvent, factory informersv1.SharedInformerFactory) cache.SharedIndexInformer { //nolint:ireturn
+func (c DefaultsCRV1) GetInformerV1(eventChan chan k8ssync.SyncDataEvent, factory informersv1.SharedInformerFactory) (cache.SharedIndexInformer, cache.ResourceEventHandlerRegistration) { //nolint:ireturn
 	informer := factory.Ingress().V1().Defaults().Informer()
 
 	sendToChannel := func(eventChan chan k8ssync.SyncDataEvent, object interface{}, status store.Status) {
@@ -131,7 +131,7 @@ func (c DefaultsCRV1) GetInformerV1(eventChan chan k8ssync.SyncDataEvent, factor
 		}
 	}
 
-	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	reg, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			sendToChannel(eventChan, obj, store.ADDED)
 		},
@@ -143,14 +143,14 @@ func (c DefaultsCRV1) GetInformerV1(eventChan chan k8ssync.SyncDataEvent, factor
 		},
 	})
 	logger.Error(err)
-	return informer
+	return informer, reg
 }
 
 func (c BackendCRV1) GetKind() string {
 	return "Backend"
 }
 
-func (c BackendCRV1) GetInformerV1(eventChan chan k8ssync.SyncDataEvent, factory informersv1.SharedInformerFactory) cache.SharedIndexInformer { //nolint:ireturn
+func (c BackendCRV1) GetInformerV1(eventChan chan k8ssync.SyncDataEvent, factory informersv1.SharedInformerFactory) (cache.SharedIndexInformer, cache.ResourceEventHandlerRegistration) { //nolint:ireturn
 	informer := factory.Ingress().V1().Backends().Informer()
 
 	sendToChannel := func(eventChan chan k8ssync.SyncDataEvent, object interface{}, status store.Status) {
@@ -179,7 +179,7 @@ func (c BackendCRV1) GetInformerV1(eventChan chan k8ssync.SyncDataEvent, factory
 		}
 	}
 
-	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	reg, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			sendToChannel(eventChan, obj, store.ADDED)
 		},
@@ -191,14 +191,14 @@ func (c BackendCRV1) GetInformerV1(eventChan chan k8ssync.SyncDataEvent, factory
 		},
 	})
 	logger.Error(err)
-	return informer
+	return informer, reg
 }
 
 func (c TCPCRV1) GetKind() string {
 	return "TCP"
 }
 
-func (c TCPCRV1) GetInformerV1(eventChan chan k8ssync.SyncDataEvent, factory informersv1.SharedInformerFactory) cache.SharedIndexInformer { //nolint:ireturn
+func (c TCPCRV1) GetInformerV1(eventChan chan k8ssync.SyncDataEvent, factory informersv1.SharedInformerFactory) (cache.SharedIndexInformer, cache.ResourceEventHandlerRegistration) { //nolint:ireturn
 	informer := factory.Ingress().V1().TCPs().Informer()
 
 	sendToChannel := func(eventChan chan k8ssync.SyncDataEvent, object interface{}, status store.Status) {
@@ -228,7 +228,7 @@ func (c TCPCRV1) GetInformerV1(eventChan chan k8ssync.SyncDataEvent, factory inf
 		}
 	}
 
-	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	reg, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			sendToChannel(eventChan, obj, store.ADDED)
 		},
@@ -240,5 +240,5 @@ func (c TCPCRV1) GetInformerV1(eventChan chan k8ssync.SyncDataEvent, factory inf
 		},
 	})
 	logger.Error(err)
-	return informer
+	return informer, reg
 }

--- a/pkg/k8s/crs-monitor.go
+++ b/pkg/k8s/crs-monitor.go
@@ -87,61 +87,40 @@ func (k k8s) RunCRSCreationMonitoring(eventChan chan k8ssync.SyncDataEvent, stop
 		for {
 			select {
 			case groupKind := <-eventCRS:
-				if groupKind.Group == "ingress.v1.haproxy.org" {
-					if _, ok := k.crsV1["ingress.v1.haproxy.org - "+groupKind.Kind]; ok {
-						// we have already created watchers for this CRD
-						continue
-					}
-				}
-				if groupKind.Group == "ingress.v3.haproxy.org" {
-					if _, ok := k.crsV3["ingress.v3.haproxy.org - "+groupKind.Kind]; ok {
-						// we have already created watchers for this CRD
-						continue
-					}
+				if k.crAlreadyWatched(groupKind) {
+					continue
 				}
 				informersSyncedEvent := &[]cache.InformerSynced{}
-				for _, namespace := range k.whiteListedNS {
-					crsV1 := map[string]CRV1{}
-					crsV3 := map[string]CRV3{}
-					switch groupKind.Group {
-					case "ingress.v1.haproxy.org":
-						switch groupKind.Kind {
-						case "Backend":
-							crsV1[groupKind.Kind] = NewBackendCRV1()
-						case "Defaults":
-							crsV1[groupKind.Kind] = NewDefaultsCRV1()
-						case "Global":
-							crsV1[groupKind.Kind] = NewGlobalCRV1()
-						case "TCP":
-							crsV1[groupKind.Kind] = NewTCPCRV1()
+				crsV1, crsV3 := lateCRMaps(groupKind, osArgs)
+				k.rememberLateCR(groupKind, crsV1, crsV3)
+				if k.sessions != nil {
+					sessions := k.sessions.snapshot()
+					for _, sess := range sessions {
+						var synced []cache.InformerSynced
+						sink := sessionResourceChan(sess, eventChan)
+						k.runCRInformers(sink, sess.stopCh, sess.namespace, &synced, crsV1, crsV3, osArgs, false, sess.crV1, sess.crV3)
+						if sess.crV1 != nil {
+							sess.crV1.Start(sess.stopCh)
 						}
-						logger.Info("Custom resource definition created, adding CR watcher for " + crsV1[groupKind.Kind].GetKind())
-					case "ingress.v3.haproxy.org":
-						ok := true
-						switch groupKind.Kind {
-						case "Backend":
-							crsV3[groupKind.Kind] = NewBackendCRV3()
-						case "Defaults":
-							crsV3[groupKind.Kind] = NewDefaultsCRV3()
-						case "Global":
-							crsV3[groupKind.Kind] = NewGlobalCRV3()
-						case "TCP":
-							crsV3[groupKind.Kind] = NewTCPCRV3()
-						case "ValidationRules":
-							if osArgs.CustomValidationRules.Name != "" {
-								crsV3[groupKind.Kind] = NewValidationCRV3()
-							} else {
-								ok = false
-							}
-						case "Frontend":
-							crsV3[groupKind.Kind] = NewFrontendCRV3()
+						if sess.crV3 != nil {
+							sess.crV3.Start(sess.stopCh)
 						}
-						if ok {
-							logger.Info("Custom resource definition created, adding CR watcher for " + crsV3[groupKind.Kind].GetKind() + " " + groupKind.Group)
+						if len(synced) > 0 {
+							cache.WaitForCacheSync(sess.stopCh, synced...)
 						}
 					}
-
-					k.runCRInformers(eventChan, stop, namespace, informersSyncedEvent, crsV1, crsV3, osArgs)
+					// WaitForCacheSync only means handlers sent on the proxy.
+					// Drain each proxy so those List events are in the store
+					// before the COMMAND rebuild (the drain COMMAND itself).
+					for _, sess := range sessions {
+						if drainSessionEvents(sess, eventChan, stop) {
+							return
+						}
+					}
+					continue
+				}
+				for _, namespace := range k.whiteListedNS {
+					k.runCRInformers(eventChan, stop, namespace, informersSyncedEvent, crsV1, crsV3, osArgs, true, nil, nil)
 				}
 
 				if !cache.WaitForCacheSync(stop, *informersSyncedEvent...) {
@@ -152,4 +131,80 @@ func (k k8s) RunCRSCreationMonitoring(eventChan chan k8ssync.SyncDataEvent, stop
 			}
 		}
 	}(eventCRS)
+}
+
+func crMapKey(group, kind string) string {
+	return group + " - " + kind
+}
+
+// crAlreadyWatched reports whether this CRD is already registered.
+func (k k8s) crAlreadyWatched(groupKind GroupKind) bool {
+	if k.crsMu != nil {
+		k.crsMu.RLock()
+		defer k.crsMu.RUnlock()
+	}
+	if groupKind.Group == "ingress.v1.haproxy.org" {
+		_, ok := k.crsV1[crMapKey(groupKind.Group, groupKind.Kind)]
+		return ok
+	}
+	if groupKind.Group == "ingress.v3.haproxy.org" {
+		_, ok := k.crsV3[crMapKey(groupKind.Group, groupKind.Kind)]
+		return ok
+	}
+	return false
+}
+
+func (k k8s) rememberLateCR(groupKind GroupKind, crsV1 map[string]CRV1, crsV3 map[string]CRV3) {
+	if k.crsMu != nil {
+		k.crsMu.Lock()
+		defer k.crsMu.Unlock()
+	}
+	for kind, cr := range crsV1 {
+		k.crsV1[crMapKey(groupKind.Group, kind)] = cr
+	}
+	for kind, cr := range crsV3 {
+		k.crsV3[crMapKey(groupKind.Group, kind)] = cr
+	}
+}
+
+func lateCRMaps(groupKind GroupKind, osArgs utils.OSArgs) (map[string]CRV1, map[string]CRV3) {
+	crsV1 := map[string]CRV1{}
+	crsV3 := map[string]CRV3{}
+	switch groupKind.Group {
+	case "ingress.v1.haproxy.org":
+		switch groupKind.Kind {
+		case "Backend":
+			crsV1[groupKind.Kind] = NewBackendCRV1()
+		case "Defaults":
+			crsV1[groupKind.Kind] = NewDefaultsCRV1()
+		case "Global":
+			crsV1[groupKind.Kind] = NewGlobalCRV1()
+		case "TCP":
+			crsV1[groupKind.Kind] = NewTCPCRV1()
+		}
+		if cr, ok := crsV1[groupKind.Kind]; ok {
+			logger.Info("Custom resource definition created, adding CR watcher for " + cr.GetKind())
+		}
+	case "ingress.v3.haproxy.org":
+		switch groupKind.Kind {
+		case "Backend":
+			crsV3[groupKind.Kind] = NewBackendCRV3()
+		case "Defaults":
+			crsV3[groupKind.Kind] = NewDefaultsCRV3()
+		case "Global":
+			crsV3[groupKind.Kind] = NewGlobalCRV3()
+		case "TCP":
+			crsV3[groupKind.Kind] = NewTCPCRV3()
+		case "ValidationRules":
+			if osArgs.CustomValidationRules.Name != "" {
+				crsV3[groupKind.Kind] = NewValidationCRV3()
+			}
+		case "Frontend":
+			crsV3[groupKind.Kind] = NewFrontendCRV3()
+		}
+		if cr, ok := crsV3[groupKind.Kind]; ok {
+			logger.Info("Custom resource definition created, adding CR watcher for " + cr.GetKind() + " " + groupKind.Group)
+		}
+	}
+	return crsV1, crsV3
 }

--- a/pkg/k8s/crs-monitor.go
+++ b/pkg/k8s/crs-monitor.go
@@ -92,33 +92,11 @@ func (k k8s) RunCRSCreationMonitoring(eventChan chan k8ssync.SyncDataEvent, stop
 				}
 				informersSyncedEvent := &[]cache.InformerSynced{}
 				crsV1, crsV3 := lateCRMaps(groupKind, osArgs)
-				k.rememberLateCR(groupKind, crsV1, crsV3)
 				if k.sessions != nil {
-					sessions := k.sessions.snapshot()
-					for _, sess := range sessions {
-						var synced []cache.InformerSynced
-						sink := sessionResourceChan(sess, eventChan)
-						k.runCRInformers(sink, sess.stopCh, sess.namespace, &synced, crsV1, crsV3, osArgs, false, sess.crV1, sess.crV3)
-						if sess.crV1 != nil {
-							sess.crV1.Start(sess.stopCh)
-						}
-						if sess.crV3 != nil {
-							sess.crV3.Start(sess.stopCh)
-						}
-						if len(synced) > 0 {
-							cache.WaitForCacheSync(sess.stopCh, synced...)
-						}
-					}
-					// WaitForCacheSync only means handlers sent on the proxy.
-					// Drain each proxy so those List events are in the store
-					// before the COMMAND rebuild (the drain COMMAND itself).
-					for _, sess := range sessions {
-						if drainSessionEvents(sess, eventChan, stop) {
-							return
-						}
-					}
+					k.registerSessionCR(groupKind, crsV1, crsV3, eventChan, stop, osArgs)
 					continue
 				}
+				k.rememberLateCR(groupKind, crsV1, crsV3)
 				for _, namespace := range k.whiteListedNS {
 					k.runCRInformers(eventChan, stop, namespace, informersSyncedEvent, crsV1, crsV3, osArgs, true, nil, nil)
 				}
@@ -131,6 +109,59 @@ func (k k8s) RunCRSCreationMonitoring(eventChan chan k8ssync.SyncDataEvent, stop
 			}
 		}
 	}(eventCRS)
+}
+
+// registerSessionCR serializes publication of the CR set with session.run and
+// Stop. Placeholders consume the updated set when their construction completes.
+func (k k8s) registerSessionCR(groupKind GroupKind, crsV1 map[string]CRV1, crsV3 map[string]CRV3,
+	eventChan chan k8ssync.SyncDataEvent, stop <-chan struct{}, osArgs utils.OSArgs,
+) {
+	k.sessions.mu.Lock()
+	defer k.sessions.mu.Unlock()
+	if k.sessions.closed || k.crAlreadyWatched(groupKind) {
+		return
+	}
+	k.rememberLateCR(groupKind, crsV1, crsV3)
+	for _, sess := range k.sessions.sessions {
+		if !sess.constructed {
+			continue
+		}
+		var synced []cache.InformerSynced
+		var regs []cache.ResourceEventHandlerRegistration
+		sk := k
+		sk.handlerRegs = &regs
+		sk.runCRInformers(sessionResourceChan(sess, eventChan), sess.stopCh, sess.namespace,
+			&synced, crsV1, crsV3, osArgs, false, sess.crV1, sess.crV3)
+		// Handler sync, rather than just informer sync, guarantees initial
+		// callbacks have sent their events before the FIFO drain.
+		for _, reg := range regs {
+			if reg != nil {
+				synced = append(synced, reg.HasSynced)
+			}
+		}
+		sess.crV1.Start(sess.stopCh)
+		sess.crV3.Start(sess.stopCh)
+		go syncSessionCR(sess, synced, eventChan, stop)
+	}
+}
+
+// Each CRD/session pair waits independently: a failed LIST must not prevent
+// another namespace or a subsequently discovered CRD from starting.
+func syncSessionCR(sess *nsSession, synced []cache.InformerSynced, eventChan chan k8ssync.SyncDataEvent, stop <-chan struct{}) {
+	waitStop := make(chan struct{})
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-stop:
+		case <-sess.stopCh:
+		case <-done:
+		}
+		close(waitStop)
+	}()
+	if cache.WaitForCacheSync(waitStop, synced...) {
+		drainSessionEvents(sess, eventChan, stop)
+	}
 }
 
 func crMapKey(group, kind string) string {

--- a/pkg/k8s/crs_monitor_test.go
+++ b/pkg/k8s/crs_monitor_test.go
@@ -1,0 +1,61 @@
+// Copyright 2019 HAProxy Technologies LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"testing"
+
+	"github.com/haproxytech/kubernetes-ingress/pkg/utils"
+)
+
+func TestRememberLateCRIsWatchedOnRematch(t *testing.T) {
+	t.Parallel()
+	k := &k8s{
+		crsV1: map[string]CRV1{},
+		crsV3: map[string]CRV3{},
+	}
+	gk := GroupKind{Group: "ingress.v3.haproxy.org", Kind: "TCP"}
+	crsV1, crsV3 := lateCRMaps(gk, utils.OSArgs{})
+	if _, ok := crsV3["TCP"]; !ok {
+		t.Fatal("lateCRMaps must produce a TCP watcher")
+	}
+	k.rememberLateCR(gk, crsV1, crsV3)
+	if _, ok := k.crsV3["ingress.v3.haproxy.org - TCP"]; !ok {
+		t.Fatal("rematch sessions read k.crsV3; late TCP CRD must be recorded there")
+	}
+	if _, ok := k.crsV3["ingress.v3.haproxy.org - TCP"]; ok {
+		if k.crsV3["ingress.v3.haproxy.org - TCP"].GetKind() != "TCP" {
+			t.Fatal("recorded CR must be TCP")
+		}
+	}
+
+	gkV1 := GroupKind{Group: "ingress.v1.haproxy.org", Kind: "Backend"}
+	v1, v3 := lateCRMaps(gkV1, utils.OSArgs{})
+	k.rememberLateCR(gkV1, v1, v3)
+	if _, ok := k.crsV1["ingress.v1.haproxy.org - Backend"]; !ok {
+		t.Fatal("late v1 Backend CRD must be recorded for rematch")
+	}
+}
+
+func TestRememberLateCRSkipLookupMatchesMonitor(t *testing.T) {
+	t.Parallel()
+	k := &k8s{crsV3: map[string]CRV3{}}
+	gk := GroupKind{Group: "ingress.v3.haproxy.org", Kind: "Frontend"}
+	_, crsV3 := lateCRMaps(gk, utils.OSArgs{})
+	k.rememberLateCR(gk, nil, crsV3)
+	if _, ok := k.crsV3["ingress.v3.haproxy.org - "+gk.Kind]; !ok {
+		t.Fatal("monitor skip key must match rememberLateCR key")
+	}
+}

--- a/pkg/k8s/informers.go
+++ b/pkg/k8s/informers.go
@@ -33,7 +33,7 @@ func (k k8s) getNamespaceInfomer(eventChan chan k8ssync.SyncDataEvent, factory i
 		go logger.Debug("Namespace informer error: %s", err)
 	})
 	logger.Error(errW)
-	_, err := informer.AddEventHandler(
+	k.noteReg(informer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				data, ok := obj.(*corev1.Namespace)
@@ -122,11 +122,10 @@ func (k k8s) getNamespaceInfomer(eventChan chan k8ssync.SyncDataEvent, factory i
 				eventChan <- ToSyncDataEvent(item2, item2, data2.UID, data2.ResourceVersion)
 			},
 		},
-	)
-	logger.Error(err)
+	))
 
 	// Use TransformFunc to modify/filter objects before passing them to handlers
-	err = informer.SetTransform(k8stransform.TransformNamespace)
+	err := informer.SetTransform(k8stransform.TransformNamespace)
 	logger.Error(err)
 	return informer
 }
@@ -137,7 +136,7 @@ func (k k8s) getServiceInformer(eventChan chan k8ssync.SyncDataEvent, factory in
 		go logger.Debug("Service informer error: %s", err)
 	})
 	logger.Error(errW)
-	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	k.noteReg(informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			data, ok := obj.(*corev1.Service)
 			if !ok {
@@ -271,11 +270,10 @@ func (k k8s) getServiceInformer(eventChan chan k8ssync.SyncDataEvent, factory in
 				}
 			}
 		},
-	})
-	logger.Error(err)
+	}))
 
 	// Use TransformFunc to modify/filter objects before passing them to handlers
-	err = informer.SetTransform(k8stransform.TransformService)
+	err := informer.SetTransform(k8stransform.TransformService)
 	logger.Error(err)
 	return informer
 }
@@ -286,7 +284,7 @@ func (k k8s) getSecretInformer(eventChan chan k8ssync.SyncDataEvent, factory inf
 		go logger.Debug("Secret informer error: %s", err)
 	})
 	logger.Error(errW)
-	_, err := informer.AddEventHandler(
+	k.noteReg(informer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				data, ok := obj.(*corev1.Secret)
@@ -348,11 +346,10 @@ func (k k8s) getSecretInformer(eventChan chan k8ssync.SyncDataEvent, factory inf
 				eventChan <- ToSyncDataEvent(item2, item2, data2.UID, data2.ResourceVersion)
 			},
 		},
-	)
-	logger.Error(err)
+	))
 
 	// Use TransformFunc to modify/filter objects before passing them to handlers
-	err = informer.SetTransform(k8stransform.TransformSecret)
+	err := informer.SetTransform(k8stransform.TransformSecret)
 	logger.Error(err)
 	return informer
 }
@@ -363,7 +360,7 @@ func (k k8s) getConfigMapInformer(eventChan chan k8ssync.SyncDataEvent, factory 
 		go logger.Debug("ConfigMap informer error: %s", err)
 	})
 	logger.Error(errW)
-	_, err := informer.AddEventHandler(
+	k.noteReg(informer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				data, ok := obj.(*corev1.ConfigMap)
@@ -432,11 +429,10 @@ func (k k8s) getConfigMapInformer(eventChan chan k8ssync.SyncDataEvent, factory 
 				eventChan <- ToSyncDataEvent(item2, item2, data2.UID, data2.ResourceVersion)
 			},
 		},
-	)
-	logger.Error(err)
+	))
 
 	// Use TransformFunc to modify/filter objects before passing them to handlers
-	err = informer.SetTransform(k8stransform.TransformConfigmap)
+	err := informer.SetTransform(k8stransform.TransformConfigmap)
 	logger.Error(err)
 	return informer
 }
@@ -453,7 +449,7 @@ func (k k8s) getIngressInformers(eventChan chan k8ssync.SyncDataEvent, factory i
 			ii = factory.Networking().V1().Ingresses().Informer()
 			logger.Debugf("watching ingress resources of apiGroup %s:", apiGroup)
 		}
-		if rs.Name == "ingressclasses" {
+		if rs.Name == "ingressclasses" && k.eventEpoch == 0 {
 			ici = factory.Networking().V1().IngressClasses().Informer()
 		}
 	}
@@ -499,7 +495,7 @@ func (k k8s) getEndpointsInformer(eventChan chan k8ssync.SyncDataEvent, factory 
 		go logger.Debug("Endpoints informer error: %s", err)
 	})
 	logger.Error(errW)
-	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	k.noteReg(informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			item, err := k.convertToEndpoints(obj, store.ADDED)
 			if errors.Is(err, ErrIgnored) {
@@ -532,11 +528,10 @@ func (k k8s) getEndpointsInformer(eventChan chan k8ssync.SyncDataEvent, factory 
 			logIncomingK8sEvent(logger, item2, uid, resourceVersion)
 			eventChan <- ToSyncDataEvent(item2, item2, uid, resourceVersion)
 		},
-	})
-	logger.Error(err)
+	}))
 
 	// Use TransformFunc to modify/filter objects before passing them to handlers
-	err = informer.SetTransform(k8stransform.TransformEndpoints)
+	err := informer.SetTransform(k8stransform.TransformEndpoints)
 	logger.Error(err)
 	return informer
 }
@@ -591,7 +586,7 @@ func (k k8s) addIngressClassHandlers(eventChan chan k8ssync.SyncDataEvent, infor
 		go logger.Debug("IngressClass informer error: %s", err)
 	})
 	logger.Error(errW)
-	_, err := informer.AddEventHandler(
+	k.noteReg(informer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				item, err := store.ConvertToIngressClass(obj)
@@ -629,11 +624,10 @@ func (k k8s) addIngressClassHandlers(eventChan chan k8ssync.SyncDataEvent, infor
 				eventChan <- ToSyncDataEvent(item, item, uid, resourceVersion)
 			},
 		},
-	)
-	logger.Error(err)
+	))
 
 	// Use TransformFunc to modify/filter objects before passing them to handlers
-	err = informer.SetTransform(k8stransform.TransformIngressClass)
+	err := informer.SetTransform(k8stransform.TransformIngressClass)
 	logger.Error(err)
 }
 
@@ -642,7 +636,7 @@ func (k k8s) addIngressHandlers(eventChan chan k8ssync.SyncDataEvent, informer c
 		go logger.Debug("Ingress informer error: %s", err)
 	})
 	logger.Error(errW)
-	_, err := informer.AddEventHandler(
+	k.noteReg(informer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				item, err := store.ConvertToIngress(obj, osArgs.EnableCustomAnnotationsOnIngress)
@@ -685,11 +679,10 @@ func (k k8s) addIngressHandlers(eventChan chan k8ssync.SyncDataEvent, informer c
 				eventChan <- ToSyncDataEvent(item, item, uid, resourceVersion)
 			},
 		},
-	)
-	logger.Error(err)
+	))
 
 	// Use TransformFunc to modify/filter objects before passing them to handlers
-	err = informer.SetTransform(k8stransform.TransformIngress)
+	err := informer.SetTransform(k8stransform.TransformIngress)
 	logger.Error(err)
 }
 
@@ -698,7 +691,7 @@ func (k k8s) addEndpointSliceHandlers(eventChan chan k8ssync.SyncDataEvent, info
 		go logger.Debug("EndpoitSlice informer error: %s", err)
 	})
 	logger.Error(errW)
-	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	k.noteReg(informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			item, err := k.convertToEndpoints(obj, store.ADDED)
 			if errors.Is(err, ErrIgnored) {
@@ -731,11 +724,10 @@ func (k k8s) addEndpointSliceHandlers(eventChan chan k8ssync.SyncDataEvent, info
 			logIncomingK8sEvent(logger, item2, uid, resourceVersion)
 			eventChan <- ToSyncDataEvent(item2, item2, uid, resourceVersion)
 		},
-	})
-	logger.Error(err)
+	}))
 
 	// Use TransformFunc to modify/filter objects before passing them to handlers
-	err = informer.SetTransform(k8stransform.TransformEndpoints)
+	err := informer.SetTransform(k8stransform.TransformEndpoints)
 	logger.Error(err)
 }
 
@@ -1006,25 +998,25 @@ func manageTCPRoute(tcproute *gatewayv1alpha2.TCPRoute, eventChan chan k8ssync.S
 
 func (k k8s) getGatewayClassesInformer(eventChan chan k8ssync.SyncDataEvent, factory gatewaynetworking.SharedInformerFactory) cache.SharedIndexInformer {
 	informer := factory.Gateway().V1beta1().GatewayClasses()
-	PopulateInformer(eventChan, informer, GatewayInformerFunc[*gatewayv1beta1.GatewayClass](manageGatewayClass))
+	k.noteReg(PopulateInformer(eventChan, informer, GatewayInformerFunc[*gatewayv1beta1.GatewayClass](manageGatewayClass)), nil)
 	return informer.Informer()
 }
 
 func (k k8s) getGatewayInformer(eventChan chan k8ssync.SyncDataEvent, factory gatewaynetworking.SharedInformerFactory) cache.SharedIndexInformer {
 	informer := factory.Gateway().V1beta1().Gateways()
-	PopulateInformer(eventChan, informer, GatewayInformerFunc[*gatewayv1beta1.Gateway](manageGateway))
+	k.noteReg(PopulateInformer(eventChan, informer, GatewayInformerFunc[*gatewayv1beta1.Gateway](manageGateway)), nil)
 	return informer.Informer()
 }
 
 func (k k8s) getTCPRouteInformer(eventChan chan k8ssync.SyncDataEvent, factory gatewaynetworking.SharedInformerFactory) cache.SharedIndexInformer {
 	informer := factory.Gateway().V1alpha2().TCPRoutes()
-	PopulateInformer(eventChan, informer, GatewayInformerFunc[*gatewayv1alpha2.TCPRoute](manageTCPRoute))
+	k.noteReg(PopulateInformer(eventChan, informer, GatewayInformerFunc[*gatewayv1alpha2.TCPRoute](manageTCPRoute)), nil)
 	return informer.Informer()
 }
 
-func PopulateInformer[IT InformerGetter, GWType GatewayRelatedType, GWF GatewayInformerFunc[GWType]](eventChan chan k8ssync.SyncDataEvent, informer IT, handler GWF) cache.SharedIndexInformer {
+func PopulateInformer[IT InformerGetter, GWType GatewayRelatedType, GWF GatewayInformerFunc[GWType]](eventChan chan k8ssync.SyncDataEvent, informer IT, handler GWF) cache.ResourceEventHandlerRegistration {
 	//revive:disable:unchecked-type-assertion
-	_, err := informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	reg, err := informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			gatewaytype := obj.(GWType)
 			handler(gatewaytype, eventChan, store.ADDED)
@@ -1040,12 +1032,12 @@ func PopulateInformer[IT InformerGetter, GWType GatewayRelatedType, GWF GatewayI
 	})
 	//revive:enable:unchecked-type-assertion
 	logger.Error(err)
-	return informer.Informer()
+	return reg
 }
 
 func (k k8s) getReferenceGrantInformer(eventChan chan k8ssync.SyncDataEvent, factory gatewaynetworking.SharedInformerFactory) cache.SharedIndexInformer {
 	informer := factory.Gateway().V1alpha2().ReferenceGrants()
-	PopulateInformer(eventChan, informer, GatewayInformerFunc[*gatewayv1alpha2.ReferenceGrant](manageReferenceGrant))
+	k.noteReg(PopulateInformer(eventChan, informer, GatewayInformerFunc[*gatewayv1alpha2.ReferenceGrant](manageReferenceGrant)), nil)
 	return informer.Informer()
 }
 

--- a/pkg/k8s/main.go
+++ b/pkg/k8s/main.go
@@ -17,10 +17,12 @@ package k8s
 import (
 	"context"
 	"errors"
+	"maps"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	k8sinformers "k8s.io/client-go/informers"
@@ -64,6 +66,16 @@ type K8s interface {
 	GetClientset() *k8sclientset.Clientset
 	MonitorChanges(eventChan chan k8ssync.SyncDataEvent, stop chan struct{}, osArgs utils.OSArgs, gatewayAPIInstalled bool)
 	IsGatewayAPIInstalled(gatewayControllerName string) bool
+	NewSessionManager(eventChan chan k8ssync.SyncDataEvent, gatewayAPI bool) NamespaceSessions
+}
+
+// NamespaceSessions is the watch lifecycle for --namespace-label-selector.
+type NamespaceSessions interface {
+	Start(namespace string) error
+	Stop(namespace string)
+	Accept(namespace string, epoch uint64) bool
+	MarkReady(namespace string, epoch uint64) bool
+	Close()
 }
 
 // A Custom Resource interface
@@ -74,12 +86,12 @@ type CRKind interface {
 }
 type CRV1 interface {
 	CRKind
-	GetInformerV1(chan k8ssync.SyncDataEvent, crinformersv1.SharedInformerFactory) cache.SharedIndexInformer //nolint:inamedparam
+	GetInformerV1(chan k8ssync.SyncDataEvent, crinformersv1.SharedInformerFactory) (cache.SharedIndexInformer, cache.ResourceEventHandlerRegistration) //nolint:inamedparam
 }
 
 type CRV3 interface {
 	CRKind
-	GetInformerV3(chan k8ssync.SyncDataEvent, crinformersv3.SharedInformerFactory, utils.OSArgs) cache.SharedIndexInformer //nolint:inamedparam
+	GetInformerV3(chan k8ssync.SyncDataEvent, crinformersv3.SharedInformerFactory, utils.OSArgs) (cache.SharedIndexInformer, cache.ResourceEventHandlerRegistration) //nolint:inamedparam
 }
 
 // k8s is structure with all data required to synchronize with k8s
@@ -103,6 +115,12 @@ type k8s struct {
 	cacheResyncPeriod      time.Duration
 	disableSvcExternalName bool // CVE-2021-25740
 	cmMain                 types.NamespacedName
+	osArgs                 utils.OSArgs
+	eventEpoch             uint64
+	handlerRegs            *[]cache.ResourceEventHandlerRegistration
+	sessions               *sessionManager
+	gatewayAPI             bool
+	crsMu                  *sync.RWMutex
 }
 
 func New(osArgs utils.OSArgs, whitelist map[string]struct{}, publishSvc *utils.NamespaceValue) K8s { //nolint:ireturn
@@ -133,7 +151,7 @@ func New(osArgs utils.OSArgs, whitelist map[string]struct{}, publishSvc *utils.N
 	}
 
 	prefix, _ := utils.GetPodPrefix(os.Getenv("POD_NAME"))
-	k := k8s{
+	k := &k8s{
 		builtInClient:          builtInClient,
 		crClientV1:             crclientsetv1.NewForConfigOrDie(restconfig),
 		crClientV3:             crclientsetv3.NewForConfigOrDie(restconfig),
@@ -156,6 +174,8 @@ func New(osArgs utils.OSArgs, whitelist map[string]struct{}, publishSvc *utils.N
 			Name:      osArgs.ConfigMap.Name,
 			Namespace: osArgs.ConfigMap.Namespace,
 		},
+		osArgs: osArgs,
+		crsMu:  &sync.RWMutex{},
 	}
 
 	// ingress/v1 is deprecated
@@ -182,12 +202,30 @@ func (k k8s) GetClientset() *k8sclientset.Clientset {
 	return k.builtInClient
 }
 
+func (k k8s) send(ch chan k8ssync.SyncDataEvent, ev k8ssync.SyncDataEvent) {
+	if k.eventEpoch != 0 {
+		ev.NamespaceEpoch = k.eventEpoch
+	}
+	ch <- ev
+}
+
+func (k k8s) noteReg(reg cache.ResourceEventHandlerRegistration, err error) {
+	logger.Error(err)
+	if k.handlerRegs != nil && reg != nil {
+		*k.handlerRegs = append(*k.handlerRegs, reg)
+	}
+}
+
 func (k k8s) MonitorChanges(eventChan chan k8ssync.SyncDataEvent, stop chan struct{}, osArgs utils.OSArgs, gatewayAPIInstalled bool) {
 	informersSynced := &[]cache.InformerSynced{}
 	k.runPodInformer(eventChan, stop, informersSynced)
+	if osArgs.NamespaceLabelSelectorActive() {
+		k.watchNamespacesByLabel(eventChan, stop, osArgs, gatewayAPIInstalled)
+		return
+	}
 	for _, namespace := range k.whiteListedNS {
 		k.runInformers(eventChan, stop, namespace, informersSynced, osArgs)
-		k.runCRInformers(eventChan, stop, namespace, informersSynced, k.crsV1, k.crsV3, osArgs)
+		k.runCRInformers(eventChan, stop, namespace, informersSynced, k.crsV1, k.crsV3, osArgs, true, nil, nil)
 		if gatewayAPIInstalled {
 			k.runInformersGwAPI(eventChan, stop, namespace, informersSynced)
 		}
@@ -227,8 +265,14 @@ func (k k8s) registerCoreCRV1(cr CRV1) {
 	groupVersion = strings.Split(resources.GroupVersion, "/")[0]
 	for _, resource := range resources.APIResources {
 		if resource.Kind == kindName {
+			if k.crsMu != nil {
+				k.crsMu.Lock()
+			}
 			k.crsV1[groupVersion+" - "+kindName] = cr
 			k.crsRegisteredOnStart[groupVersion+" - "+kindName] = struct{}{}
+			if k.crsMu != nil {
+				k.crsMu.Unlock()
+			}
 			logger.Infof("%s CR defined in API %s", kindName, resources.GroupVersion)
 			break
 		}
@@ -246,8 +290,14 @@ func (k k8s) registerCoreCRV3(cr CRV3) {
 	groupVersion = strings.Split(resources.GroupVersion, "/")[0]
 	for _, resource := range resources.APIResources {
 		if resource.Kind == kindName {
+			if k.crsMu != nil {
+				k.crsMu.Lock()
+			}
 			k.crsV3[groupVersion+" - "+kindName] = cr
 			k.crsRegisteredOnStart[groupVersion+" - "+kindName] = struct{}{}
+			if k.crsMu != nil {
+				k.crsMu.Unlock()
+			}
 			logger.Infof("%s CR defined in API %s", kindName, resources.GroupVersion)
 			break
 		}
@@ -256,21 +306,43 @@ func (k k8s) registerCoreCRV3(cr CRV3) {
 
 func (k k8s) runCRInformers(eventChan chan k8ssync.SyncDataEvent, stop chan struct{}, namespace string,
 	informersSynced *[]cache.InformerSynced, crsV1 map[string]CRV1, crsV3 map[string]CRV3,
-	osArgs utils.OSArgs,
+	osArgs utils.OSArgs, startEach bool, informerFactoryV1 crinformersv1.SharedInformerFactory, informerFactoryV3 crinformersv3.SharedInformerFactory,
 ) {
-	informerFactoryV3 := crinformersv3.NewSharedInformerFactoryWithOptions(k.crClientV3, k.cacheResyncPeriod, crinformersv3.WithNamespace(namespace))
-	informerFactoryV1 := crinformersv1.NewSharedInformerFactoryWithOptions(k.crClientV1, k.cacheResyncPeriod, crinformersv1.WithNamespace(namespace))
+	if informerFactoryV3 == nil {
+		informerFactoryV3 = crinformersv3.NewSharedInformerFactoryWithOptions(k.crClientV3, k.cacheResyncPeriod, crinformersv3.WithNamespace(namespace))
+	}
+	if informerFactoryV1 == nil {
+		informerFactoryV1 = crinformersv1.NewSharedInformerFactoryWithOptions(k.crClientV1, k.cacheResyncPeriod, crinformersv1.WithNamespace(namespace))
+	}
 
 	for _, cr := range crsV1 {
-		informer := cr.GetInformerV1(eventChan, informerFactoryV1)
-		go informer.Run(stop)
+		informer, reg := cr.GetInformerV1(eventChan, informerFactoryV1)
+		k.noteReg(reg, nil)
+		if startEach {
+			go informer.Run(stop)
+		}
 		*informersSynced = append(*informersSynced, informer.HasSynced)
 	}
 	for _, cr := range crsV3 {
-		informer := cr.GetInformerV3(eventChan, informerFactoryV3, osArgs)
-		go informer.Run(stop)
+		if cr.GetKind() == "ValidationRules" && !startEach &&
+			(osArgs.CustomValidationRules.Name == "" || namespace != osArgs.CustomValidationRules.Namespace) {
+			continue
+		}
+		informer, reg := cr.GetInformerV3(eventChan, informerFactoryV3, osArgs)
+		k.noteReg(reg, nil)
+		if startEach {
+			go informer.Run(stop)
+		}
 		*informersSynced = append(*informersSynced, informer.HasSynced)
 	}
+}
+
+func (k k8s) crsSnapshot() (map[string]CRV1, map[string]CRV3) {
+	if k.crsMu != nil {
+		k.crsMu.RLock()
+		defer k.crsMu.RUnlock()
+	}
+	return maps.Clone(k.crsV1), maps.Clone(k.crsV3)
 }
 
 func (k k8s) runConfigMapInformers(eventChan chan k8ssync.SyncDataEvent, stop chan struct{}, informersSynced *[]cache.InformerSynced, configMap utils.NamespaceValue) {

--- a/pkg/k8s/session.go
+++ b/pkg/k8s/session.go
@@ -1,0 +1,408 @@
+// Copyright 2019 HAProxy Technologies LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"fmt"
+	"sync"
+
+	crinformersv1 "github.com/haproxytech/kubernetes-ingress/crs/generated/api/ingress/v1/informers/externalversions"
+	crinformersv3 "github.com/haproxytech/kubernetes-ingress/crs/generated/api/ingress/v3/informers/externalversions"
+	k8ssync "github.com/haproxytech/kubernetes-ingress/pkg/k8s/sync"
+	"k8s.io/client-go/tools/cache"
+	gatewaynetworking "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions"
+)
+
+type sessionPhase uint8
+
+const (
+	sessionStarting sessionPhase = iota
+	sessionReady
+	sessionStopping
+)
+
+type nsSession struct {
+	namespace string
+	epoch     uint64
+	phase     sessionPhase
+	stopCh    chan struct{}
+	stopOnce  sync.Once
+	handlers  []cache.ResourceEventHandlerRegistration
+	shutdown  func()
+	crV1      crinformersv1.SharedInformerFactory
+	crV3      crinformersv3.SharedInformerFactory
+	gw        gatewaynetworking.SharedInformerFactory
+	proxy     chan k8ssync.SyncDataEvent
+	// run starts informers. Start calls it only after the session is in the
+	// manager map so Accept sees this generation and Stop can cancel it.
+	run func()
+}
+
+// sessionStarter creates factories and handlers for one namespace. It must not
+// start informers or wait for cache sync; Start publishes the session, then
+// calls sess.run, then waits for ready.
+type sessionStarter func(namespace string, epoch uint64, stopCh chan struct{}) (*nsSession, error)
+
+type sessionManager struct {
+	mu        sync.RWMutex
+	readyCond *sync.Cond
+	sessions  map[string]*nsSession
+	nextEpoch map[string]uint64
+	closed    bool
+	eventChan chan k8ssync.SyncDataEvent
+	starter   sessionStarter
+}
+
+func newSessionManager(eventChan chan k8ssync.SyncDataEvent, starter sessionStarter) *sessionManager {
+	m := &sessionManager{
+		sessions:  map[string]*nsSession{},
+		nextEpoch: map[string]uint64{},
+		eventChan: eventChan,
+		starter:   starter,
+	}
+	m.readyCond = sync.NewCond(&m.mu)
+	return m
+}
+
+// Start creates a session for namespace if none is current. It does not wait
+// for informer sync. The session is published before informers run so Accept
+// and Stop observe it during starter(), and a DELETE can cancel an in-flight Start.
+func (m *sessionManager) Start(namespace string) error {
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return nil
+	}
+	if _, ok := m.sessions[namespace]; ok {
+		m.mu.Unlock()
+		return nil
+	}
+	m.nextEpoch[namespace]++
+	epoch := m.nextEpoch[namespace]
+	stopCh := make(chan struct{})
+	placeholder := &nsSession{
+		namespace: namespace,
+		epoch:     epoch,
+		phase:     sessionStarting,
+		stopCh:    stopCh,
+	}
+	m.sessions[namespace] = placeholder
+	m.mu.Unlock()
+
+	sess, err := m.starter(namespace, epoch, stopCh)
+	if err != nil {
+		m.dropPlaceholder(namespace, placeholder)
+		m.shutdownSession(placeholder)
+		return fmt.Errorf("start namespace session %s: %w", namespace, err)
+	}
+	if sess == nil {
+		m.dropPlaceholder(namespace, placeholder)
+		m.shutdownSession(placeholder)
+		return fmt.Errorf("start namespace session %s: starter returned nil", namespace)
+	}
+	sess.namespace = namespace
+	sess.epoch = epoch
+	sess.phase = sessionStarting
+	if sess.stopCh == nil {
+		sess.stopCh = stopCh
+	}
+
+	m.mu.Lock()
+	current, ok := m.sessions[namespace]
+	if m.closed || !ok || current != placeholder {
+		m.mu.Unlock()
+		if sess.shutdown != nil {
+			go sess.shutdown()
+		}
+		return nil
+	}
+	m.sessions[namespace] = sess
+	// Starting the informer goroutines is part of publishing the session.
+	// Keep it serialized with Stop so shutdown cannot overtake run setup.
+	if sess.run != nil {
+		sess.run()
+	}
+	m.mu.Unlock()
+	go m.waitAndSignalReady(sess)
+	return nil
+}
+
+func (m *sessionManager) dropPlaceholder(namespace string, placeholder *nsSession) {
+	m.mu.Lock()
+	if current, ok := m.sessions[namespace]; ok && current == placeholder {
+		delete(m.sessions, namespace)
+		m.readyCond.Broadcast()
+	}
+	m.mu.Unlock()
+}
+
+func (m *sessionManager) waitAndSignalReady(sess *nsSession) {
+	synced := true
+	if len(sess.handlers) > 0 {
+		fns := make([]cache.InformerSynced, 0, len(sess.handlers))
+		for _, h := range sess.handlers {
+			if h != nil {
+				fns = append(fns, h.HasSynced)
+			}
+		}
+		if len(fns) > 0 {
+			synced = cache.WaitForCacheSync(sess.stopCh, fns...)
+		}
+	}
+	if !synced {
+		return
+	}
+	m.mu.Lock()
+	current, ok := m.sessions[sess.namespace]
+	stillCurrent := ok && current == sess && current.phase == sessionStarting && !m.closed
+	m.mu.Unlock()
+	if !stillCurrent {
+		return
+	}
+	done := make(chan struct{})
+	ev := k8ssync.SyncDataEvent{
+		SyncType:       k8ssync.NAMESPACE_SESSION_READY,
+		Namespace:      sess.namespace,
+		NamespaceEpoch: sess.epoch,
+		EventProcessed: done,
+	}
+	readyChan := m.eventChan
+	if sess.proxy != nil {
+		readyChan = sess.proxy
+	}
+	select {
+	case <-sess.stopCh:
+		return
+	case readyChan <- ev:
+	}
+	select {
+	case <-sess.stopCh:
+		return
+	case <-done:
+	}
+	m.mu.Lock()
+	current, ok = m.sessions[sess.namespace]
+	if ok && current == sess && current.phase == sessionStarting && !m.closed {
+		sess.phase = sessionReady
+		m.readyCond.Broadcast()
+	}
+	m.mu.Unlock()
+}
+
+func (m *sessionManager) Stop(namespace string) {
+	m.mu.Lock()
+	sess, ok := m.sessions[namespace]
+	if ok {
+		sess.phase = sessionStopping
+		delete(m.sessions, namespace)
+		m.readyCond.Broadcast()
+	}
+	m.mu.Unlock()
+	if !ok {
+		return
+	}
+	m.shutdownSession(sess)
+}
+
+func (m *sessionManager) shutdownSession(sess *nsSession) {
+	if sess == nil {
+		return
+	}
+	sess.stopOnce.Do(func() {
+		if sess.stopCh != nil {
+			close(sess.stopCh)
+		}
+	})
+	if sess.shutdown != nil {
+		go sess.shutdown()
+	}
+}
+
+func (m *sessionManager) Accept(namespace string, epoch uint64) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	sess, ok := m.sessions[namespace]
+	return ok && sess.epoch == epoch && sess.phase != sessionStopping && !m.closed
+}
+
+func (m *sessionManager) MarkReady(namespace string, epoch uint64) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	sess, ok := m.sessions[namespace]
+	if !ok || sess.epoch != epoch || sess.phase == sessionStopping || m.closed {
+		return false
+	}
+	// Phase flips to Ready in waitAndSignalReady after EventProcessed, so
+	// WaitAllReady does not return before the store is marked Relevant.
+	return true
+}
+
+func (m *sessionManager) Close() {
+	m.mu.Lock()
+	m.closed = true
+	all := make([]*nsSession, 0, len(m.sessions))
+	for name, sess := range m.sessions {
+		sess.phase = sessionStopping
+		all = append(all, sess)
+		delete(m.sessions, name)
+	}
+	m.readyCond.Broadcast()
+	m.mu.Unlock()
+	for _, sess := range all {
+		m.shutdownSession(sess)
+	}
+}
+
+func (m *sessionManager) WaitAllReady(stop <-chan struct{}) bool {
+	stopClosed := make(chan struct{})
+	defer close(stopClosed)
+	go func() {
+		select {
+		case <-stop:
+			m.mu.Lock()
+			m.readyCond.Broadcast()
+			m.mu.Unlock()
+		case <-stopClosed:
+		}
+	}()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for {
+		select {
+		case <-stop:
+			return false
+		default:
+		}
+		if m.closed {
+			return false
+		}
+		allReady := true
+		for _, sess := range m.sessions {
+			if sess.phase == sessionStarting {
+				allReady = false
+				break
+			}
+		}
+		if allReady {
+			return true
+		}
+		m.readyCond.Wait()
+	}
+}
+
+// stampSessionEvents copies in to out, setting NamespaceEpoch on every event.
+// Session informers must send on `in` (the per-session proxy), not the process
+// eventChan, so late CRD watchers keep the current generation.
+//
+// When stop is closed, it stops blocking on out and keeps reading in until
+// that channel is closed so informer Shutdown can finish. A nil stop never
+// fires, which tests use.
+func stampSessionEvents(in <-chan k8ssync.SyncDataEvent, out chan<- k8ssync.SyncDataEvent, stop <-chan struct{}, epoch uint64) {
+	forward := func(ev k8ssync.SyncDataEvent) bool {
+		ev.NamespaceEpoch = epoch
+		select {
+		case out <- ev:
+			return true
+		case <-stop:
+			return false
+		}
+	}
+	for {
+		select {
+		case ev, ok := <-in:
+			if !ok {
+				return
+			}
+			if !forward(ev) {
+				for range in {
+				}
+				return
+			}
+		case <-stop:
+			for range in {
+			}
+			return
+		}
+	}
+}
+
+// closeSessionProxyAfter runs wait (factory Shutdown / gateway informer
+// WaitGroup) then closes proxy so the stamp goroutine can exit. wait must
+// return only after informers will no longer send on proxy.
+func closeSessionProxyAfter(wait func(), proxy chan k8ssync.SyncDataEvent, stampDone *sync.WaitGroup) {
+	if wait != nil {
+		wait()
+	}
+	close(proxy)
+	if stampDone != nil {
+		stampDone.Wait()
+	}
+}
+
+// sessionResourceChan is the channel late CR informers must send on. Using the
+// process eventChan would leave NamespaceEpoch at 0 and SyncData would drop the
+// events.
+func sessionResourceChan(sess *nsSession, processChan chan k8ssync.SyncDataEvent) chan k8ssync.SyncDataEvent {
+	if sess != nil && sess.proxy != nil {
+		return sess.proxy
+	}
+	return processChan
+}
+
+// drainSessionEvents queues a COMMAND on the session proxy (so it is FIFO
+// after List events already sent there) and waits until SyncData has
+// processed it. Sending COMMAND on processChan directly can overtake events
+// still in the proxy. Returns true if process stop is closed.
+func drainSessionEvents(sess *nsSession, processChan chan k8ssync.SyncDataEvent, stop <-chan struct{}) bool {
+	if sess == nil {
+		return false
+	}
+	ch := sessionResourceChan(sess, processChan)
+	if ch == nil {
+		return false
+	}
+	ep := make(chan struct{})
+	ev := k8ssync.SyncDataEvent{SyncType: k8ssync.COMMAND, EventProcessed: ep}
+	var sessionStop <-chan struct{}
+	if sess.stopCh != nil {
+		sessionStop = sess.stopCh
+	}
+	select {
+	case <-stop:
+		return true
+	case <-sessionStop:
+		return false
+	case ch <- ev:
+	}
+	select {
+	case <-stop:
+		return true
+	case <-sessionStop:
+		return false
+	case <-ep:
+		return false
+	}
+}
+
+func (m *sessionManager) snapshot() []*nsSession {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]*nsSession, 0, len(m.sessions))
+	for _, sess := range m.sessions {
+		out = append(out, sess)
+	}
+	return out
+}

--- a/pkg/k8s/session.go
+++ b/pkg/k8s/session.go
@@ -45,6 +45,10 @@ type nsSession struct {
 	crV3      crinformersv3.SharedInformerFactory
 	gw        gatewaynetworking.SharedInformerFactory
 	proxy     chan k8ssync.SyncDataEvent
+	// proxyMu coordinates non-informer sends with proxy closure.
+	proxyMu     sync.RWMutex
+	proxyClosed bool
+	constructed bool
 	// run starts informers. Start calls it only after the session is in the
 	// manager map so Accept sees this generation and Stop can cancel it.
 	run func()
@@ -128,6 +132,7 @@ func (m *sessionManager) Start(namespace string) error {
 		}
 		return nil
 	}
+	sess.constructed = true
 	m.sessions[namespace] = sess
 	// Starting the informer goroutines is part of publishing the session.
 	// Keep it serialized with Stop so shutdown cannot overtake run setup.
@@ -182,10 +187,8 @@ func (m *sessionManager) waitAndSignalReady(sess *nsSession) {
 	if sess.proxy != nil {
 		readyChan = sess.proxy
 	}
-	select {
-	case <-sess.stopCh:
+	if !sess.sendEvent(readyChan, ev, nil) {
 		return
-	case readyChan <- ev:
 	}
 	select {
 	case <-sess.stopCh:
@@ -340,13 +343,13 @@ func stampSessionEvents(in <-chan k8ssync.SyncDataEvent, out chan<- k8ssync.Sync
 }
 
 // closeSessionProxyAfter runs wait (factory Shutdown / gateway informer
-// WaitGroup) then closes proxy so the stamp goroutine can exit. wait must
-// return only after informers will no longer send on proxy.
-func closeSessionProxyAfter(wait func(), proxy chan k8ssync.SyncDataEvent, stampDone *sync.WaitGroup) {
+// WaitGroup), excludes READY/drain senders, then closes proxy so the stamp
+// goroutine can exit. wait must return only after informers stop sending.
+func closeSessionProxyAfter(wait func(), sess *nsSession, stampDone *sync.WaitGroup) {
 	if wait != nil {
 		wait()
 	}
-	close(proxy)
+	sess.closeProxy()
 	if stampDone != nil {
 		stampDone.Wait()
 	}
@@ -380,12 +383,13 @@ func drainSessionEvents(sess *nsSession, processChan chan k8ssync.SyncDataEvent,
 	if sess.stopCh != nil {
 		sessionStop = sess.stopCh
 	}
-	select {
-	case <-stop:
-		return true
-	case <-sessionStop:
-		return false
-	case ch <- ev:
+	if !sess.sendEvent(ch, ev, stop) {
+		select {
+		case <-stop:
+			return true
+		default:
+			return false
+		}
 	}
 	select {
 	case <-stop:
@@ -395,6 +399,31 @@ func drainSessionEvents(sess *nsSession, processChan chan k8ssync.SyncDataEvent,
 	case <-ep:
 		return false
 	}
+}
+
+// sendEvent holds the proxy open until this send finishes. A stop check alone
+// cannot protect a select containing a send on a closed channel.
+func (sess *nsSession) sendEvent(ch chan k8ssync.SyncDataEvent, ev k8ssync.SyncDataEvent, stop <-chan struct{}) bool {
+	sess.proxyMu.RLock()
+	defer sess.proxyMu.RUnlock()
+	if sess.proxyClosed {
+		return false
+	}
+	select {
+	case <-stop:
+		return false
+	case <-sess.stopCh:
+		return false
+	case ch <- ev:
+		return true
+	}
+}
+
+func (sess *nsSession) closeProxy() {
+	sess.proxyMu.Lock()
+	defer sess.proxyMu.Unlock()
+	sess.proxyClosed = true
+	close(sess.proxy)
 }
 
 func (m *sessionManager) snapshot() []*nsSession {

--- a/pkg/k8s/session_cr_test.go
+++ b/pkg/k8s/session_cr_test.go
@@ -1,0 +1,331 @@
+// Copyright 2026 HAProxy Technologies LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	crclientv1 "github.com/haproxytech/kubernetes-ingress/crs/generated/api/ingress/v1/clientset/versioned"
+	crclientv3 "github.com/haproxytech/kubernetes-ingress/crs/generated/api/ingress/v3/clientset/versioned"
+	crinformersv3 "github.com/haproxytech/kubernetes-ingress/crs/generated/api/ingress/v3/informers/externalversions"
+	k8ssync "github.com/haproxytech/kubernetes-ingress/pkg/k8s/sync"
+	"github.com/haproxytech/kubernetes-ingress/pkg/utils"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+func awaitSessionTest(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for session activity")
+	}
+}
+
+// Use HTTP-backed clients and the production starter, including the actual
+// generated factories, handler registrations and LIST/WATCH lifecycle.
+func sessionCRClient(t *testing.T, lists chan<- string) *k8s {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("sendInitialEvents") == "true" {
+			http.Error(w, "watch-list unsupported", http.StatusBadRequest)
+			return
+		}
+		if r.URL.Query().Get("watch") == "true" {
+			w.WriteHeader(http.StatusOK)
+			w.(http.Flusher).Flush()
+			<-r.Context().Done()
+			return
+		}
+		if r.URL.Path == "/apis/networking.k8s.io/v1" {
+			_, _ = w.Write([]byte(`{"kind":"APIResourceList","groupVersion":"networking.k8s.io/v1","resources":[{"name":"ingresses","kind":"Ingress","namespaced":true}]}`))
+			return
+		}
+		if !strings.Contains(r.URL.Path, "/namespaces/") {
+			http.NotFound(w, r)
+			return
+		}
+		parts := strings.Split(r.URL.Path, "/")
+		resource := parts[len(parts)-1]
+		if strings.Contains(r.URL.Path, "ingress.v3.haproxy.org") {
+			lists <- r.URL.Path
+			if strings.Contains(r.URL.Path, "/bad/") && resource == "tcps" {
+				http.Error(w, "forbidden", http.StatusForbidden)
+				return
+			}
+		}
+		kinds := map[string]string{"services": "ServiceList", "secrets": "SecretList", "ingresses": "IngressList", "endpoints": "EndpointsList", "tcps": "TCPList", "backends": "BackendList"}
+		version := "v1"
+		if resource == "ingresses" {
+			version = "networking.k8s.io/v1"
+		}
+		if strings.Contains(r.URL.Path, "ingress.v3.haproxy.org") {
+			version = "ingress.v3.haproxy.org/v3"
+		}
+		items := []interface{}{}
+		if resource == "tcps" || resource == "backends" {
+			items = append(items, map[string]interface{}{
+				"apiVersion": version, "kind": strings.TrimSuffix(kinds[resource], "List"),
+				"metadata": map[string]string{"namespace": parts[len(parts)-2], "name": "initial", "resourceVersion": "1"},
+			})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"kind": kinds[resource], "apiVersion": version, "metadata": map[string]string{"resourceVersion": "1"}, "items": items})
+	}))
+	t.Cleanup(server.Close)
+	cfg := &rest.Config{Host: server.URL, QPS: 1000, Burst: 1000}
+	k := &k8s{builtInClient: kubernetes.NewForConfigOrDie(cfg), crClientV1: crclientv1.NewForConfigOrDie(cfg), crClientV3: crclientv3.NewForConfigOrDie(cfg), crsV1: map[string]CRV1{}, crsV3: map[string]CRV3{}, crsMu: &sync.RWMutex{}}
+	k.sessions = newSessionManager(make(chan k8ssync.SyncDataEvent, 100), k.startNSSession)
+	t.Cleanup(k.sessions.Close)
+	return k
+}
+
+type countingSessionCR struct {
+	CRV3
+	registrations atomic.Int32
+}
+
+func (cr *countingSessionCR) GetInformerV3(ch chan k8ssync.SyncDataEvent, factory crinformersv3.SharedInformerFactory, args utils.OSArgs) (cache.SharedIndexInformer, cache.ResourceEventHandlerRegistration) {
+	cr.registrations.Add(1)
+	return cr.CRV3.GetInformerV3(ch, factory, args)
+}
+
+func TestCRRegistrationDuringSessionConstruction(t *testing.T) {
+	lists := make(chan string, 100)
+	k := sessionCRClient(t, lists)
+	constructed, release := make(chan struct{}), make(chan struct{})
+	k.sessions.starter = func(ns string, epoch uint64, stop chan struct{}) (*nsSession, error) {
+		sess, err := k.startNSSession(ns, epoch, stop)
+		close(constructed)
+		<-release
+		return sess, err
+	}
+	started := make(chan struct{})
+	go func() {
+		defer close(started)
+		if err := k.sessions.Start("app"); err != nil {
+			t.Error(err)
+		}
+	}()
+	awaitSessionTest(t, constructed)
+	group := GroupKind{Group: "ingress.v3.haproxy.org", Kind: "TCP"}
+	v1, v3 := lateCRMaps(group, utils.OSArgs{})
+	cr := &countingSessionCR{CRV3: v3["TCP"]}
+	v3["TCP"] = cr
+	stop := make(chan struct{})
+	defer close(stop)
+	k.registerSessionCR(group, v1, v3, k.sessions.eventChan, stop, utils.OSArgs{})
+	close(release)
+	awaitSessionTest(t, started)
+	select {
+	case path := <-lists:
+		if !strings.HasSuffix(path, "/tcps") {
+			t.Fatalf("unexpected LIST %s", path)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("CR registered during construction was missed")
+	}
+	// Repeated discovery must not add a second registration to the factory.
+	k.registerSessionCR(group, v1, v3, k.sessions.eventChan, stop, utils.OSArgs{})
+	k.sessions.mu.RLock()
+	sess := k.sessions.sessions["app"]
+	count := len(sess.handlers)
+	k.sessions.mu.RUnlock()
+	if count != 5 {
+		t.Fatalf("handler count = %d, want four core handlers plus TCP", count)
+	}
+	if got := cr.registrations.Load(); got != 1 {
+		t.Fatalf("CR registrations = %d, want 1", got)
+	}
+}
+
+func TestLateCRSyncDoesNotBlockNamespacesOrFutureCRDs(t *testing.T) {
+	lists := make(chan string, 100)
+	k := sessionCRClient(t, lists)
+	// COMMAND has no namespace; distinct epochs identify its session of origin.
+	k.sessions.nextEpoch["healthy"] = 10
+	for _, ns := range []string{"bad", "healthy"} {
+		if err := k.sessions.Start(ns); err != nil {
+			t.Fatal(err)
+		}
+	}
+	stop := make(chan struct{})
+	defer close(stop)
+	for _, kind := range []string{"TCP", "Backend"} {
+		group := GroupKind{Group: "ingress.v3.haproxy.org", Kind: kind}
+		v1, v3 := lateCRMaps(group, utils.OSArgs{})
+		returned := make(chan struct{})
+		go func() {
+			k.registerSessionCR(group, v1, v3, k.sessions.eventChan, stop, utils.OSArgs{})
+			close(returned)
+		}()
+		awaitSessionTest(t, returned)
+		// Register Backend only after TCP's own drain. Otherwise a Backend
+		// COMMAND could hide a missing or prematurely emitted TCP drain.
+		seen := map[string]bool{}
+		drained := map[uint64]bool{}
+		wantDrains := 1
+		if kind == "Backend" {
+			wantDrains = 2
+		}
+		deadline := time.After(5 * time.Second)
+		for len(drained) < wantDrains {
+			select {
+			case ev := <-k.sessions.eventChan:
+				if ev.EventProcessed != nil {
+					close(ev.EventProcessed)
+				}
+				switch ev.SyncType {
+				case k8ssync.CR_TCP, k8ssync.CR_BACKEND:
+					if string(ev.SyncType) != kind || ev.Name != "initial" {
+						t.Fatalf("unexpected CR event: %+v", ev)
+					}
+					seen[ev.Namespace] = true
+				case k8ssync.COMMAND:
+					ns := "bad"
+					if ev.NamespaceEpoch == 11 {
+						ns = "healthy"
+					} else if ev.NamespaceEpoch != 1 {
+						t.Fatalf("unexpected drain epoch: %d", ev.NamespaceEpoch)
+					}
+					if !seen[ns] || drained[ev.NamespaceEpoch] {
+						t.Fatalf("%s drain without preceding %s event (or duplicate): %+v", ns, kind, ev)
+					}
+					drained[ev.NamespaceEpoch] = true
+				}
+			case <-deadline:
+				t.Fatalf("%s did not progress: events=%v drains=%v", kind, seen, drained)
+			}
+		}
+		k.sessions.mu.RLock()
+		badTCP := k.sessions.sessions["bad"].crV3.Ingress().V3().TCPs().Informer()
+		k.sessions.mu.RUnlock()
+		if badTCP.HasSynced() {
+			t.Fatalf("bad/TCP synced despite forbidden LIST during %s progression", kind)
+		}
+	}
+	want := map[string]bool{"bad/tcps": false, "healthy/tcps": false, "bad/backends": false, "healthy/backends": false}
+	deadline := time.After(5 * time.Second)
+	for remaining := len(want); remaining > 0; {
+		select {
+		case path := <-lists:
+			for key, seen := range want {
+				if !seen && strings.HasSuffix(path, "/"+key) {
+					want[key] = true
+					remaining--
+				}
+			}
+		case <-deadline:
+			t.Fatalf("missing LIST requests: %v", want)
+		}
+	}
+}
+
+func TestLateCRSyncCancellation(t *testing.T) {
+	for _, name := range []string{"process", "session"} {
+		t.Run(name, func(t *testing.T) {
+			sess := &nsSession{stopCh: make(chan struct{})}
+			stop, done, entered := make(chan struct{}), make(chan struct{}), make(chan struct{})
+			var once sync.Once
+			go func() {
+				syncSessionCR(sess, []cache.InformerSynced{func() bool { once.Do(func() { close(entered) }); return false }}, nil, stop)
+				close(done)
+			}()
+			awaitSessionTest(t, entered)
+			if name == "process" {
+				close(stop)
+			} else {
+				close(sess.stopCh)
+			}
+			awaitSessionTest(t, done)
+		})
+	}
+}
+
+func TestClosedSessionProxyRejectsReadyAndDrain(t *testing.T) {
+	sess := &nsSession{namespace: "app", epoch: 1, stopCh: make(chan struct{}), proxy: make(chan k8ssync.SyncDataEvent)}
+	m := newSessionManager(nil, nil)
+	m.sessions["app"] = sess
+	close(sess.stopCh)
+	sess.closeProxy()
+	for range 1000 {
+		m.waitAndSignalReady(sess)
+		if drainSessionEvents(sess, nil, nil) {
+			t.Fatal("process was not stopped")
+		}
+	}
+}
+
+func TestSessionProxyCloseWaitsForSenders(t *testing.T) {
+	for _, name := range []string{"READY", "drain"} {
+		t.Run(name, func(t *testing.T) {
+			sess := &nsSession{namespace: "app", epoch: 1, phase: sessionStarting, stopCh: make(chan struct{}), proxy: make(chan k8ssync.SyncDataEvent)}
+			m := newSessionManager(nil, nil)
+			m.sessions["app"] = sess
+			var stopOnce sync.Once
+			stop := func() { stopOnce.Do(func() { close(sess.stopCh) }) }
+			t.Cleanup(stop)
+			sent := make(chan struct{})
+			go func() {
+				defer close(sent)
+				if name == "READY" {
+					m.waitAndSignalReady(sess)
+				} else if drainSessionEvents(sess, nil, nil) {
+					t.Error("session cancellation reported process stop")
+				}
+			}()
+			// No proxy receiver exists: the real sender must hold its lease
+			// while blocked. Observe it without manufacturing a reader lock.
+			deadline := time.After(5 * time.Second)
+			tick := time.NewTicker(time.Millisecond)
+			defer tick.Stop()
+			for sess.proxyMu.TryLock() {
+				sess.proxyMu.Unlock()
+				select {
+				case <-tick.C:
+				case <-deadline:
+					t.Fatal("blocked sender did not hold the proxy open")
+				}
+			}
+			waitEntered, releaseWait, closed := make(chan struct{}), make(chan struct{}), make(chan struct{})
+			go func() {
+				closeSessionProxyAfter(func() { close(waitEntered); <-releaseWait }, sess, nil)
+				close(closed)
+			}()
+			awaitSessionTest(t, waitEntered)
+			close(releaseWait)
+			select {
+			case <-closed:
+				t.Fatal("closed proxy with a blocked real sender")
+			case <-time.After(20 * time.Millisecond):
+			}
+			stop()
+			awaitSessionTest(t, sent)
+			awaitSessionTest(t, closed)
+			if _, ok := <-sess.proxy; ok {
+				t.Fatal("proxy was not closed")
+			}
+		})
+	}
+}

--- a/pkg/k8s/session_test.go
+++ b/pkg/k8s/session_test.go
@@ -1,0 +1,577 @@
+// Copyright 2019 HAProxy Technologies LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	crinformersv1 "github.com/haproxytech/kubernetes-ingress/crs/generated/api/ingress/v1/informers/externalversions"
+	crinformersv3 "github.com/haproxytech/kubernetes-ingress/crs/generated/api/ingress/v3/informers/externalversions"
+	k8ssync "github.com/haproxytech/kubernetes-ingress/pkg/k8s/sync"
+	"github.com/haproxytech/kubernetes-ingress/pkg/utils"
+	"k8s.io/client-go/tools/cache"
+)
+
+func fakeStarter() sessionStarter {
+	return func(namespace string, epoch uint64, stopCh chan struct{}) (*nsSession, error) {
+		return &nsSession{
+			namespace: namespace,
+			epoch:     epoch,
+			stopCh:    stopCh,
+			shutdown:  func() {},
+		}, nil
+	}
+}
+
+func drainReady(ch <-chan k8ssync.SyncDataEvent, n int, timeout time.Duration) int {
+	got := 0
+	deadline := time.After(timeout)
+	for got < n {
+		select {
+		case ev := <-ch:
+			if ev.EventProcessed != nil {
+				close(ev.EventProcessed)
+			}
+			if ev.SyncType == k8ssync.NAMESPACE_SESSION_READY {
+				got++
+			}
+		case <-deadline:
+			return got
+		}
+	}
+	return got
+}
+
+func TestNewSessionManagerBindsStarterAfterSessions(t *testing.T) {
+	t.Parallel()
+	k := &k8s{osArgs: utils.OSArgs{NamespaceLabelSelector: "app=watch"}}
+	ch := make(chan k8ssync.SyncDataEvent, 1)
+	got := k.NewSessionManager(ch, false)
+	if got == nil {
+		t.Fatal("selector-only NewSessionManager must return a manager")
+	}
+	if k.sessions == nil || k.sessions.starter == nil {
+		t.Fatal("sessions and starter must both be set")
+	}
+	defer func() {
+		if rec := recover(); rec != nil {
+			t.Logf("starter panicked without a client (expected): %v", rec)
+		}
+	}()
+	_, err := k.sessions.starter("app", 1, make(chan struct{}))
+	if err != nil && strings.Contains(err.Error(), "session manager is nil") {
+		t.Fatalf("method-value bind copied k before sessions was assigned: %v", err)
+	}
+}
+
+func TestSessionManagerStartStopEpoch(t *testing.T) {
+	t.Parallel()
+	ch := make(chan k8ssync.SyncDataEvent, 8)
+	m := newSessionManager(ch, fakeStarter())
+
+	if err := m.Start("app"); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Start("app"); err != nil {
+		t.Fatal(err)
+	}
+	if got := drainReady(ch, 1, 2*time.Second); got != 1 {
+		t.Fatalf("ready events = %d, want 1", got)
+	}
+	if !m.Accept("app", 1) {
+		t.Fatal("current epoch 1 must be accepted")
+	}
+	if m.Accept("app", 99) {
+		t.Fatal("stale epoch must be rejected")
+	}
+
+	m.Stop("app")
+	if m.Accept("app", 1) {
+		t.Fatal("stopped session must reject")
+	}
+
+	if err := m.Start("app"); err != nil {
+		t.Fatal(err)
+	}
+	if got := drainReady(ch, 1, 2*time.Second); got != 1 {
+		t.Fatalf("second generation ready = %d", got)
+	}
+	if m.Accept("app", 1) {
+		t.Fatal("old generation must be rejected after rematch")
+	}
+	if !m.Accept("app", 2) {
+		t.Fatal("new generation must be accepted")
+	}
+}
+
+func TestStartPublishesSessionBeforeInformersRun(t *testing.T) {
+	t.Parallel()
+	ch := make(chan k8ssync.SyncDataEvent, 8)
+	ran := make(chan struct{})
+	m := newSessionManager(ch, nil)
+	m.starter = func(namespace string, epoch uint64, stopCh chan struct{}) (*nsSession, error) {
+		if !m.Accept(namespace, epoch) {
+			t.Error("session must be visible to Accept before informers start")
+		}
+		return &nsSession{
+			namespace: namespace,
+			epoch:     epoch,
+			stopCh:    stopCh,
+			shutdown:  func() {},
+			run:       func() { close(ran) },
+		}, nil
+	}
+	if err := m.Start("app"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-ran:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run was not called")
+	}
+	if !m.Accept("app", 1) {
+		t.Fatal("session must remain accepted after run")
+	}
+	m.Stop("app")
+	select {
+	case ev := <-ch:
+		if ev.EventProcessed != nil {
+			close(ev.EventProcessed)
+		}
+	default:
+	}
+}
+
+func TestStopDuringStartPreventsInformersRun(t *testing.T) {
+	t.Parallel()
+	ch := make(chan k8ssync.SyncDataEvent, 8)
+	inStarter := make(chan struct{})
+	release := make(chan struct{})
+	ran := make(chan struct{})
+	m := newSessionManager(ch, nil)
+	m.starter = func(namespace string, epoch uint64, stopCh chan struct{}) (*nsSession, error) {
+		close(inStarter)
+		<-release
+		return &nsSession{
+			stopCh:   stopCh,
+			shutdown: func() {},
+			run:      func() { close(ran) },
+		}, nil
+	}
+	errCh := make(chan error, 1)
+	go func() { errCh <- m.Start("app") }()
+	<-inStarter
+	if !m.Accept("app", 1) {
+		t.Fatal("placeholder must be accepted during Start")
+	}
+	m.Stop("app")
+	close(release)
+	if err := <-errCh; err != nil {
+		t.Fatal(err)
+	}
+	if m.Accept("app", 1) {
+		t.Fatal("stopped in-flight session must not remain")
+	}
+	select {
+	case <-ran:
+		t.Fatal("informers must not start after Stop")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestStopWaitsForSessionRunSetup(t *testing.T) {
+	t.Parallel()
+	ch := make(chan k8ssync.SyncDataEvent, 8)
+	runStarted := make(chan struct{})
+	releaseRun := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			close(releaseRun)
+		})
+	}
+	t.Cleanup(release)
+
+	m := newSessionManager(ch, nil)
+	m.starter = func(namespace string, epoch uint64, stopCh chan struct{}) (*nsSession, error) {
+		return &nsSession{
+			namespace: namespace,
+			epoch:     epoch,
+			stopCh:    stopCh,
+			run: func() {
+				close(runStarted)
+				<-releaseRun
+			},
+			shutdown: func() {},
+		}, nil
+	}
+
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- m.Start("app")
+	}()
+	select {
+	case <-runStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("session run setup did not start")
+	}
+
+	stopStarted := make(chan struct{})
+	stopDone := make(chan struct{})
+	go func() {
+		close(stopStarted)
+		m.Stop("app")
+		close(stopDone)
+	}()
+	<-stopStarted
+	select {
+	case <-stopDone:
+		t.Fatal("Stop returned before session run setup completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	release()
+	select {
+	case err := <-startDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after run setup completed")
+	}
+	select {
+	case <-stopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not return after run setup completed")
+	}
+	if m.Accept("app", 1) {
+		t.Fatal("stopped session must not remain accepted")
+	}
+}
+
+func TestSessionManagerMarkReadyAndClose(t *testing.T) {
+	t.Parallel()
+	ch := make(chan k8ssync.SyncDataEvent, 8)
+	m := newSessionManager(ch, fakeStarter())
+	if err := m.Start("app"); err != nil {
+		t.Fatal(err)
+	}
+	go func() { drainReady(ch, 1, 2*time.Second) }()
+	if !m.WaitAllReady(make(chan struct{})) {
+		t.Fatal("empty stop, session should become ready")
+	}
+	if !m.MarkReady("app", 1) {
+		t.Fatal("MarkReady current epoch")
+	}
+	if m.MarkReady("app", 2) {
+		t.Fatal("MarkReady wrong epoch")
+	}
+
+	m.Close()
+	if err := m.Start("other"); err != nil {
+		t.Fatal(err)
+	}
+	if m.Accept("other", 1) {
+		t.Fatal("Start after Close must be no-op")
+	}
+	if m.Accept("app", 1) {
+		t.Fatal("Close must drop sessions")
+	}
+}
+
+func TestSessionReadyFollowsInitialProxyEvents(t *testing.T) {
+	t.Parallel()
+	eventChan := make(chan k8ssync.SyncDataEvent, 4)
+	proxy := make(chan k8ssync.SyncDataEvent, 2)
+	startStamp := make(chan struct{})
+	stampDone := make(chan struct{})
+	shutdownDone := make(chan struct{})
+	go func() {
+		<-startStamp
+		stampSessionEvents(proxy, eventChan, nil, 7)
+		close(stampDone)
+	}()
+
+	m := newSessionManager(eventChan, func(namespace string, epoch uint64, stopCh chan struct{}) (*nsSession, error) {
+		proxy <- k8ssync.SyncDataEvent{SyncType: k8ssync.CR_TCP, Namespace: namespace, Name: "initial"}
+		return &nsSession{
+			namespace: namespace,
+			epoch:     epoch,
+			stopCh:    stopCh,
+			proxy:     proxy,
+			shutdown: func() {
+				close(proxy)
+				<-stampDone
+				close(shutdownDone)
+			},
+		}, nil
+	})
+	if err := m.Start("app"); err != nil {
+		t.Fatal(err)
+	}
+	close(startStamp)
+
+	first := <-eventChan
+	second := <-eventChan
+	if first.SyncType != k8ssync.CR_TCP || second.SyncType != k8ssync.NAMESPACE_SESSION_READY {
+		t.Fatalf("event order = [%s, %s], want [CR_TCP, NAMESPACE_SESSION_READY]", first.SyncType, second.SyncType)
+	}
+	if second.EventProcessed == nil {
+		t.Fatal("READY must carry an EventProcessed barrier")
+	}
+	close(second.EventProcessed)
+	m.Stop("app")
+	select {
+	case <-shutdownDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("session shutdown did not finish")
+	}
+}
+
+func TestDrainSessionEventsWaitsForPriorProxyEvents(t *testing.T) {
+	t.Parallel()
+	process := make(chan k8ssync.SyncDataEvent, 4)
+	proxy := make(chan k8ssync.SyncDataEvent, 2)
+	stop := make(chan struct{})
+	sessStop := make(chan struct{})
+	sess := &nsSession{proxy: proxy, stopCh: sessStop}
+
+	stampDone := make(chan struct{})
+	go func() {
+		stampSessionEvents(proxy, process, nil, 4)
+		close(stampDone)
+	}()
+
+	proxy <- k8ssync.SyncDataEvent{SyncType: k8ssync.CR_TCP, Namespace: "app", Name: "tcp"}
+
+	drained := make(chan bool, 1)
+	go func() {
+		drained <- drainSessionEvents(sess, process, stop)
+	}()
+
+	first := <-process
+	second := <-process
+	if first.SyncType != k8ssync.CR_TCP {
+		t.Fatalf("first = %s, want CR_TCP", first.SyncType)
+	}
+	if second.SyncType != k8ssync.COMMAND {
+		t.Fatalf("second = %s, want COMMAND", second.SyncType)
+	}
+	if second.EventProcessed == nil {
+		t.Fatal("drain COMMAND must carry EventProcessed")
+	}
+	close(second.EventProcessed)
+	select {
+	case stopped := <-drained:
+		if stopped {
+			t.Fatal("process stop was not closed")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("drainSessionEvents did not return after EventProcessed")
+	}
+	close(proxy)
+	<-stampDone
+}
+
+func TestDrainSessionEventsReturnsOnSessionStop(t *testing.T) {
+	t.Parallel()
+	process := make(chan k8ssync.SyncDataEvent)
+	proxy := make(chan k8ssync.SyncDataEvent)
+	stop := make(chan struct{})
+	sessStop := make(chan struct{})
+	close(sessStop)
+	sess := &nsSession{proxy: proxy, stopCh: sessStop}
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- drainSessionEvents(sess, process, stop)
+	}()
+	select {
+	case stopped := <-done:
+		if stopped {
+			t.Fatal("session stop must not report process stop")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("drainSessionEvents must return when the session is stopped")
+	}
+	select {
+	case <-process:
+		t.Fatal("stopped session must not send a drain COMMAND")
+	default:
+	}
+}
+
+func TestRunCRInformersTracksSessionHandlers(t *testing.T) {
+	t.Parallel()
+	var regs []cache.ResourceEventHandlerRegistration
+	k := k8s{handlerRegs: &regs}
+	v1Factory := crinformersv1.NewSharedInformerFactory(nil, 0)
+	v3Factory := crinformersv3.NewSharedInformerFactory(nil, 0)
+	var synced []cache.InformerSynced
+	k.runCRInformers(
+		make(chan k8ssync.SyncDataEvent, 2),
+		make(chan struct{}),
+		"app",
+		&synced,
+		nil,
+		map[string]CRV3{
+			"TCP":             NewTCPCRV3(),
+			"ValidationRules": NewValidationCRV3(),
+		},
+		utils.OSArgs{CustomValidationRules: utils.NamespaceValue{Namespace: "app", Name: "rules"}},
+		false,
+		v1Factory,
+		v3Factory,
+	)
+	if len(regs) != 2 {
+		t.Fatalf("handler registrations = %d, want 2", len(regs))
+	}
+	if len(synced) != 2 {
+		t.Fatalf("informer sync funcs = %d, want 2", len(synced))
+	}
+}
+
+func TestStampSessionEventsSetsEpochOnCRTCP(t *testing.T) {
+	t.Parallel()
+	in := make(chan k8ssync.SyncDataEvent, 1)
+	out := make(chan k8ssync.SyncDataEvent, 1)
+	done := make(chan struct{})
+	go func() {
+		stampSessionEvents(in, out, nil, 7)
+		close(done)
+	}()
+	in <- k8ssync.SyncDataEvent{SyncType: k8ssync.CR_TCP, Namespace: "app", Name: "tcp"}
+	close(in)
+	ev := <-out
+	if ev.NamespaceEpoch != 7 {
+		t.Fatalf("NamespaceEpoch = %d, want 7", ev.NamespaceEpoch)
+	}
+	if ev.SyncType != k8ssync.CR_TCP {
+		t.Fatalf("SyncType = %s", ev.SyncType)
+	}
+	<-done
+}
+
+func TestSessionResourceChanUsesProxy(t *testing.T) {
+	t.Parallel()
+	process := make(chan k8ssync.SyncDataEvent)
+	proxy := make(chan k8ssync.SyncDataEvent)
+	sess := &nsSession{proxy: proxy, epoch: 3}
+	if got := sessionResourceChan(sess, process); got != proxy {
+		t.Fatal("late CRD watchers must send on the session proxy so epoch is stamped")
+	}
+	if got := sessionResourceChan(nil, process); got != process {
+		t.Fatal("non-session path must keep the process channel")
+	}
+}
+
+func TestCloseSessionProxyAfterWaitsBeforeClose(t *testing.T) {
+	t.Parallel()
+	proxy := make(chan k8ssync.SyncDataEvent)
+	var stampWg sync.WaitGroup
+	stampWg.Add(1)
+	go func() {
+		defer stampWg.Done()
+		for range proxy {
+		}
+	}()
+	sent := make(chan struct{})
+	wait := func() {
+		proxy <- k8ssync.SyncDataEvent{SyncType: k8ssync.GATEWAY, Namespace: "app"}
+		close(sent)
+	}
+	closeSessionProxyAfter(wait, proxy, &stampWg)
+	select {
+	case <-sent:
+	default:
+		t.Fatal("proxy was closed before gateway wait returned")
+	}
+}
+
+func TestStampSessionEventsUnblocksOnStop(t *testing.T) {
+	t.Parallel()
+	in := make(chan k8ssync.SyncDataEvent, 1)
+	out := make(chan k8ssync.SyncDataEvent) // unbuffered, no receiver
+	stop := make(chan struct{})
+	in <- k8ssync.SyncDataEvent{SyncType: k8ssync.CR_TCP, Namespace: "app", Name: "tcp"}
+
+	done := make(chan struct{})
+	go func() {
+		stampSessionEvents(in, out, stop, 1)
+		close(done)
+	}()
+
+	close(stop)
+	close(in)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stampSessionEvents stayed blocked on eventChan after stop")
+	}
+}
+
+func TestWaitAllReadyReturnsOnStop(t *testing.T) {
+	t.Parallel()
+	ch := make(chan k8ssync.SyncDataEvent, 8)
+	m := newSessionManager(ch, fakeStarter())
+	if err := m.Start("app"); err != nil {
+		t.Fatal(err)
+	}
+	stop := make(chan struct{})
+	done := make(chan bool, 1)
+	go func() {
+		done <- m.WaitAllReady(stop)
+	}()
+	close(stop)
+	select {
+	case ready := <-done:
+		if ready {
+			t.Fatal("WaitAllReady must be false when stop is closed before Ready")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitAllReady did not return after stop")
+	}
+	// Unblock waitAndSignalReady so the test does not leak the READY waiter.
+	select {
+	case ev := <-ch:
+		if ev.EventProcessed != nil {
+			close(ev.EventProcessed)
+		}
+	default:
+	}
+}
+
+func TestSessionManagerConcurrentStop(t *testing.T) {
+	t.Parallel()
+	ch := make(chan k8ssync.SyncDataEvent, 8)
+	m := newSessionManager(ch, fakeStarter())
+	if err := m.Start("app"); err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			m.Stop("app")
+			m.Stop("app")
+		}()
+	}
+	wg.Wait()
+	m.Close()
+}

--- a/pkg/k8s/session_test.go
+++ b/pkg/k8s/session_test.go
@@ -495,7 +495,7 @@ func TestCloseSessionProxyAfterWaitsBeforeClose(t *testing.T) {
 		proxy <- k8ssync.SyncDataEvent{SyncType: k8ssync.GATEWAY, Namespace: "app"}
 		close(sent)
 	}
-	closeSessionProxyAfter(wait, proxy, &stampWg)
+	closeSessionProxyAfter(wait, &nsSession{proxy: proxy}, &stampWg)
 	select {
 	case <-sent:
 	default:

--- a/pkg/k8s/sync/sync.go
+++ b/pkg/k8s/sync/sync.go
@@ -29,29 +29,45 @@ type SyncDataEvent struct {
 	Name            string
 	UID             types.UID
 	ResourceVersion string
+	NamespaceEpoch  uint64
+	IsInInitialList bool
 }
 
 //nolint:golint,stylecheck
 const (
 	// SyncType values
-	COMMAND         SyncType = "COMMAND"
-	CONFIGMAP       SyncType = "CONFIGMAP"
-	ENDPOINTS       SyncType = "ENDPOINTS"
-	INGRESS         SyncType = "INGRESS"
-	INGRESS_CLASS   SyncType = "INGRESS_CLASS"
-	NAMESPACE       SyncType = "NAMESPACE"
-	POD             SyncType = "POD"
-	SERVICE         SyncType = "SERVICE"
-	SECRET          SyncType = "SECRET"
-	CR_GLOBAL       SyncType = "Global"
-	CR_DEFAULTS     SyncType = "Defaults"
-	CR_BACKEND      SyncType = "Backend"
-	CR_TCP          SyncType = "TCP"
-	CR_FRONTEND     SyncType = "Frontend"
-	PUBLISH_SERVICE SyncType = "PUBLISH_SERVICE"
-	GATEWAYCLASS    SyncType = "GATEWAYCLASS"
-	GATEWAY         SyncType = "GATEWAY"
-	TCPROUTE        SyncType = "TCPROUTE"
-	REFERENCEGRANT  SyncType = "REFERENCEGRANT"
-	CUSTOM_RESOURCE SyncType = "CUSTOM_RESOURCE"
+	COMMAND                 SyncType = "COMMAND"
+	CONFIGMAP               SyncType = "CONFIGMAP"
+	ENDPOINTS               SyncType = "ENDPOINTS"
+	INGRESS                 SyncType = "INGRESS"
+	INGRESS_CLASS           SyncType = "INGRESS_CLASS"
+	NAMESPACE               SyncType = "NAMESPACE"
+	POD                     SyncType = "POD"
+	SERVICE                 SyncType = "SERVICE"
+	SECRET                  SyncType = "SECRET"
+	CR_GLOBAL               SyncType = "Global"
+	CR_DEFAULTS             SyncType = "Defaults"
+	CR_BACKEND              SyncType = "Backend"
+	CR_TCP                  SyncType = "TCP"
+	CR_FRONTEND             SyncType = "Frontend"
+	PUBLISH_SERVICE         SyncType = "PUBLISH_SERVICE"
+	GATEWAYCLASS            SyncType = "GATEWAYCLASS"
+	GATEWAY                 SyncType = "GATEWAY"
+	TCPROUTE                SyncType = "TCPROUTE"
+	REFERENCEGRANT          SyncType = "REFERENCEGRANT"
+	CUSTOM_RESOURCE         SyncType = "CUSTOM_RESOURCE"
+	NAMESPACE_SESSION_READY SyncType = "NAMESPACE_SESSION_READY"
 )
+
+// IsNamespacedSessionEvent reports whether the event is emitted by a
+// per-namespace session and must be epoch-checked in selector mode.
+func IsNamespacedSessionEvent(t SyncType) bool {
+	switch t {
+	case SERVICE, SECRET, INGRESS, ENDPOINTS,
+		CR_GLOBAL, CR_DEFAULTS, CR_BACKEND, CR_FRONTEND, CR_TCP,
+		GATEWAY, TCPROUTE, REFERENCEGRANT, PUBLISH_SERVICE, CUSTOM_RESOURCE:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/k8s/sync/sync.go
+++ b/pkg/k8s/sync/sync.go
@@ -36,6 +36,7 @@ type SyncDataEvent struct {
 //nolint:golint,stylecheck
 const (
 	// SyncType values
+	BARRIER                 SyncType = "BARRIER"
 	COMMAND                 SyncType = "COMMAND"
 	CONFIGMAP               SyncType = "CONFIGMAP"
 	ENDPOINTS               SyncType = "ENDPOINTS"

--- a/pkg/k8s/sync/sync_test.go
+++ b/pkg/k8s/sync/sync_test.go
@@ -1,0 +1,22 @@
+package k8ssync
+
+import "testing"
+
+func TestIsNamespacedSessionEvent(t *testing.T) {
+	t.Parallel()
+	namespaced := []SyncType{
+		SERVICE, SECRET, INGRESS, ENDPOINTS,
+		CR_GLOBAL, CR_DEFAULTS, CR_BACKEND, CR_FRONTEND, CR_TCP,
+		GATEWAY, TCPROUTE, REFERENCEGRANT, PUBLISH_SERVICE, CUSTOM_RESOURCE,
+	}
+	for _, typ := range namespaced {
+		if !IsNamespacedSessionEvent(typ) {
+			t.Errorf("%s should be a namespaced session event", typ)
+		}
+	}
+	for _, typ := range []SyncType{NAMESPACE, COMMAND, CONFIGMAP, POD, INGRESS_CLASS, GATEWAYCLASS, NAMESPACE_SESSION_READY} {
+		if IsNamespacedSessionEvent(typ) {
+			t.Errorf("%s must not be epoch-checked", typ)
+		}
+	}
+}

--- a/pkg/k8s/sync/sync_test.go
+++ b/pkg/k8s/sync/sync_test.go
@@ -14,7 +14,7 @@ func TestIsNamespacedSessionEvent(t *testing.T) {
 			t.Errorf("%s should be a namespaced session event", typ)
 		}
 	}
-	for _, typ := range []SyncType{NAMESPACE, COMMAND, CONFIGMAP, POD, INGRESS_CLASS, GATEWAYCLASS, NAMESPACE_SESSION_READY} {
+	for _, typ := range []SyncType{NAMESPACE, BARRIER, COMMAND, CONFIGMAP, POD, INGRESS_CLASS, GATEWAYCLASS, NAMESPACE_SESSION_READY} {
 		if IsNamespacedSessionEvent(typ) {
 			t.Errorf("%s must not be epoch-checked", typ)
 		}

--- a/pkg/k8s/watch.go
+++ b/pkg/k8s/watch.go
@@ -1,0 +1,305 @@
+// Copyright 2019 HAProxy Technologies LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/haproxytech/client-native/v6/models"
+	v3 "github.com/haproxytech/kubernetes-ingress/crs/api/ingress/v3"
+	crinformersv1 "github.com/haproxytech/kubernetes-ingress/crs/generated/api/ingress/v1/informers/externalversions"
+	crinformersv3 "github.com/haproxytech/kubernetes-ingress/crs/generated/api/ingress/v3/informers/externalversions"
+	k8ssync "github.com/haproxytech/kubernetes-ingress/pkg/k8s/sync"
+	"github.com/haproxytech/kubernetes-ingress/pkg/store"
+	"github.com/haproxytech/kubernetes-ingress/pkg/utils"
+	gatewaynetworking "sigs.k8s.io/gateway-api/pkg/client/informers/externalversions"
+)
+
+func (k *k8s) NewSessionManager(eventChan chan k8ssync.SyncDataEvent, gatewayAPI bool) NamespaceSessions {
+	if k == nil || !k.osArgs.NamespaceLabelSelectorActive() {
+		return nil
+	}
+	k.gatewayAPI = gatewayAPI
+	// Assign k.sessions before taking the startNSSession method value.
+	// A value-receiver method value copies the struct at bind time; binding
+	// before this assignment made every Start fail with "session manager is nil".
+	m := newSessionManager(eventChan, nil)
+	k.sessions = m
+	m.starter = k.startNSSession
+	return m
+}
+
+func (k *k8s) startNSSession(namespace string, epoch uint64, stopCh chan struct{}) (*nsSession, error) {
+	if k.sessions == nil {
+		return nil, fmt.Errorf("session manager is nil")
+	}
+	eventChan := k.sessions.eventChan
+	proxy := make(chan k8ssync.SyncDataEvent, 64)
+	var stampWg sync.WaitGroup
+	stampWg.Add(1)
+	go func() {
+		defer stampWg.Done()
+		stampSessionEvents(proxy, eventChan, stopCh, epoch)
+	}()
+
+	var regs []cache.ResourceEventHandlerRegistration
+	sk := *k
+	sk.eventEpoch = epoch
+	sk.handlerRegs = &regs
+
+	sess := &nsSession{
+		namespace: namespace,
+		epoch:     epoch,
+		stopCh:    stopCh,
+	}
+
+	core := k8sinformers.NewSharedInformerFactoryWithOptions(k.builtInClient, k.cacheResyncPeriod, k8sinformers.WithNamespace(namespace))
+	sk.getServiceInformer(proxy, core)
+	sk.getSecretInformer(proxy, core)
+	ii, ici := sk.getIngressInformers(proxy, core, k.osArgs)
+	if ii == nil {
+		close(proxy)
+		stampWg.Wait()
+		return nil, fmt.Errorf("ingress resource not supported")
+	}
+	_ = ici
+	epsi := sk.getEndpointSliceInformer(proxy, core)
+	if epsi == nil || !k.endpointsMirroring() {
+		sk.getEndpointsInformer(proxy, core)
+	}
+
+	crsV1, crsV3 := k.crsSnapshot()
+	crV1 := crinformersv1.NewSharedInformerFactoryWithOptions(k.crClientV1, k.cacheResyncPeriod, crinformersv1.WithNamespace(namespace))
+	crV3 := crinformersv3.NewSharedInformerFactoryWithOptions(k.crClientV3, k.cacheResyncPeriod, crinformersv3.WithNamespace(namespace))
+	sk.runCRInformers(proxy, stopCh, namespace, &[]cache.InformerSynced{}, crsV1, crsV3, k.osArgs, false, crV1, crV3)
+
+	var gw gatewaynetworking.SharedInformerFactory
+	var gwWait sync.WaitGroup
+	var gwRun []cache.SharedIndexInformer
+	if k.gatewayAPI && k.gatewayClient != nil {
+		gw = gatewaynetworking.NewSharedInformerFactoryWithOptions(k.gatewayClient, k.cacheResyncPeriod, gatewaynetworking.WithNamespace(namespace))
+		for _, inf := range []cache.SharedIndexInformer{
+			sk.getGatewayInformer(proxy, gw),
+			sk.getTCPRouteInformer(proxy, gw),
+			sk.getReferenceGrantInformer(proxy, gw),
+		} {
+			if inf == nil {
+				continue
+			}
+			gwRun = append(gwRun, inf)
+		}
+	}
+
+	sess.handlers = regs
+	sess.crV1 = crV1
+	sess.crV3 = crV3
+	sess.gw = gw
+	sess.proxy = proxy
+	sess.run = func() {
+		for _, inf := range gwRun {
+			gwWait.Add(1)
+			go func(inf cache.SharedIndexInformer) {
+				defer gwWait.Done()
+				inf.Run(stopCh)
+			}(inf)
+		}
+		core.Start(stopCh)
+		crV1.Start(stopCh)
+		crV3.Start(stopCh)
+	}
+	sess.shutdown = func() {
+		closeSessionProxyAfter(func() {
+			core.Shutdown()
+			crV1.Shutdown()
+			crV3.Shutdown()
+			gwWait.Wait()
+		}, proxy, &stampWg)
+	}
+	return sess, nil
+}
+
+func (k k8s) watchNamespacesByLabel(eventChan chan k8ssync.SyncDataEvent, stop chan struct{}, osArgs utils.OSArgs, gatewayAPIInstalled bool) {
+	if k.sessions == nil {
+		logger.Panic("namespace-label-selector is active but session manager is nil")
+	}
+	selector := osArgs.NamespaceLabelSelectorCanonical()
+	informersSynced := &[]cache.InformerSynced{}
+
+	k.runConfigMapInformers(eventChan, stop, informersSynced, osArgs.ConfigMap)
+	k.runConfigMapInformers(eventChan, stop, informersSynced, osArgs.ConfigMapTCPServices)
+	k.runConfigMapInformers(eventChan, stop, informersSynced, osArgs.ConfigMapErrorFiles)
+	k.runConfigMapInformers(eventChan, stop, informersSynced, osArgs.ConfigMapPatternFiles)
+	k.runProcessLevelIngressClass(eventChan, stop, informersSynced)
+	if gatewayAPIInstalled {
+		k.runProcessLevelGatewayClass(eventChan, stop, informersSynced)
+	}
+
+	nsFactory := k8sinformers.NewSharedInformerFactoryWithOptions(k.builtInClient, k.cacheResyncPeriod,
+		k8sinformers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.LabelSelector = selector
+		}))
+	var nsRegs []cache.ResourceEventHandlerRegistration
+	k.handlerRegs = &nsRegs
+	nsInformer := k.getSelectorNamespaceInformer(eventChan, nsFactory)
+	k.handlerRegs = nil
+	nsFactory.Start(stop)
+	synced := []cache.InformerSynced{nsInformer.HasSynced}
+	for _, reg := range nsRegs {
+		if reg != nil {
+			synced = append(synced, reg.HasSynced)
+		}
+	}
+	if !cache.WaitForCacheSync(stop, synced...) {
+		logger.Panic("Caches are not populated due to an underlying error, cannot run the Ingress Controller")
+	}
+
+	for _, obj := range nsInformer.GetStore().List() {
+		ns, ok := obj.(*corev1.Namespace)
+		if !ok || ns == nil {
+			continue
+		}
+		if err := k.sessions.Start(ns.Name); err != nil {
+			logger.Panic(err)
+		}
+	}
+	if !k.sessions.WaitAllReady(stop) {
+		logger.Panic("Caches are not populated due to an underlying error, cannot run the Ingress Controller")
+	}
+
+	k.RunCRSCreationMonitoring(eventChan, stop, osArgs)
+
+	if !cache.WaitForCacheSync(stop, *informersSynced...) {
+		logger.Panic("Caches are not populated due to an underlying error, cannot run the Ingress Controller")
+	}
+
+	syncPeriod := k.syncPeriod
+	initialSyncPeriod := k.initialSyncPeriod
+	logger.Debugf("Executing first transaction after %s", initialSyncPeriod.String())
+	logger.Debugf("Executing new transaction every %s", syncPeriod.String())
+	time.Sleep(k.initialSyncPeriod)
+	eventChan <- k8ssync.SyncDataEvent{SyncType: k8ssync.COMMAND}
+	for {
+		time.Sleep(syncPeriod)
+		ep := make(chan struct{})
+		eventChan <- k8ssync.SyncDataEvent{
+			SyncType:       k8ssync.COMMAND,
+			EventProcessed: ep,
+		}
+		<-ep
+	}
+}
+
+func (k k8s) runProcessLevelIngressClass(eventChan chan k8ssync.SyncDataEvent, stop chan struct{}, informersSynced *[]cache.InformerSynced) {
+	factory := k8sinformers.NewSharedInformerFactory(k.builtInClient, k.cacheResyncPeriod)
+	ici := factory.Networking().V1().IngressClasses().Informer()
+	k.addIngressClassHandlers(eventChan, ici)
+	factory.Start(stop)
+	*informersSynced = append(*informersSynced, ici.HasSynced)
+}
+
+func (k k8s) runProcessLevelGatewayClass(eventChan chan k8ssync.SyncDataEvent, stop chan struct{}, informersSynced *[]cache.InformerSynced) {
+	factory := gatewaynetworking.NewSharedInformerFactory(k.gatewayClient, k.cacheResyncPeriod)
+	gwclassInf := k.getGatewayClassesInformer(eventChan, factory)
+	if gwclassInf != nil {
+		factory.Start(stop)
+		*informersSynced = append(*informersSynced, gwclassInf.HasSynced)
+	}
+}
+
+func (k k8s) getSelectorNamespaceInformer(eventChan chan k8ssync.SyncDataEvent, factory k8sinformers.SharedInformerFactory) cache.SharedIndexInformer {
+	informer := factory.Core().V1().Namespaces().Informer()
+	errW := informer.SetWatchErrorHandler(func(r *cache.Reflector, err error) {
+		go logger.Debug("Namespace selector informer error: %s", err)
+	})
+	logger.Error(errW)
+	k.noteReg(informer.AddEventHandler(cache.ResourceEventHandlerDetailedFuncs{
+		AddFunc: func(obj interface{}, isInInitialList bool) {
+			item := namespaceStoreItem(obj, store.ADDED)
+			if item == nil {
+				return
+			}
+			ev := ToSyncDataEvent(item, item, "", "")
+			ev.IsInInitialList = isInInitialList
+			k.send(eventChan, ev)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			item := namespaceStoreItem(newObj, store.MODIFIED)
+			if item == nil {
+				return
+			}
+			k.send(eventChan, ToSyncDataEvent(item, item, "", ""))
+		},
+		DeleteFunc: func(obj interface{}) {
+			ns, ok := obj.(*corev1.Namespace)
+			if !ok {
+				tombstone, tsOK := obj.(cache.DeletedFinalStateUnknown)
+				if !tsOK {
+					logger.Errorf("%s: Invalid data from k8s api, %s", k8ssync.NAMESPACE, obj)
+					return
+				}
+				ns, ok = tombstone.Obj.(*corev1.Namespace)
+				if !ok {
+					logger.Errorf("%s: DeletedFinalStateUnknown contained non-Namespace object: %v", k8ssync.NAMESPACE, tombstone.Obj)
+					return
+				}
+			}
+			item := namespaceStoreItem(ns, store.DELETED)
+			if item == nil {
+				return
+			}
+			k.send(eventChan, ToSyncDataEvent(item, item, "", ""))
+		},
+	}))
+	return informer
+}
+
+func namespaceStoreItem(obj interface{}, status store.Status) *store.Namespace {
+	data, ok := obj.(*corev1.Namespace)
+	if !ok {
+		logger.Errorf("%s: Invalid data from k8s api, %s", k8ssync.NAMESPACE, obj)
+		return nil
+	}
+	if status == store.ADDED && data.ObjectMeta.GetDeletionTimestamp() != nil {
+		status = store.DELETED
+	}
+	return &store.Namespace{
+		Name:                     data.GetName(),
+		Endpoints:                make(map[string]map[string]*store.Endpoints),
+		Services:                 make(map[string]*store.Service),
+		Ingresses:                make(map[string]*store.Ingress),
+		Secret:                   make(map[string]*store.Secret),
+		HAProxyRuntime:           make(map[string]map[string]*store.RuntimeBackend),
+		HAProxyRuntimeStandalone: make(map[string]map[string]map[string]*store.RuntimeBackend),
+		CRs: &store.CustomResources{
+			Global:    map[string]*models.Global{},
+			Defaults:  map[string]*models.Defaults{},
+			Backends:  map[string]*v3.BackendSpec{},
+			TCPsPerCR: map[string]*store.TCPs{},
+			Frontends: map[string]*v3.FrontendSpec{},
+		},
+		Gateways:        make(map[string]*store.Gateway),
+		TCPRoutes:       make(map[string]*store.TCPRoute),
+		ReferenceGrants: make(map[string]*store.ReferenceGrant),
+		Labels:          utils.CopyMap(data.Labels),
+		Status:          status,
+	}
+}

--- a/pkg/k8s/watch.go
+++ b/pkg/k8s/watch.go
@@ -87,10 +87,8 @@ func (k *k8s) startNSSession(namespace string, epoch uint64, stopCh chan struct{
 		sk.getEndpointsInformer(proxy, core)
 	}
 
-	crsV1, crsV3 := k.crsSnapshot()
 	crV1 := crinformersv1.NewSharedInformerFactoryWithOptions(k.crClientV1, k.cacheResyncPeriod, crinformersv1.WithNamespace(namespace))
 	crV3 := crinformersv3.NewSharedInformerFactoryWithOptions(k.crClientV3, k.cacheResyncPeriod, crinformersv3.WithNamespace(namespace))
-	sk.runCRInformers(proxy, stopCh, namespace, &[]cache.InformerSynced{}, crsV1, crsV3, k.osArgs, false, crV1, crV3)
 
 	var gw gatewaynetworking.SharedInformerFactory
 	var gwWait sync.WaitGroup
@@ -115,6 +113,12 @@ func (k *k8s) startNSSession(namespace string, epoch uint64, stopCh chan struct{
 	sess.gw = gw
 	sess.proxy = proxy
 	sess.run = func() {
+		// The manager lock serializes this snapshot with late CR registration.
+		// Construction may have overlapped CRD discovery while only a placeholder
+		// was published; read the latest set now, not in the starter.
+		crsV1, crsV3 := k.crsSnapshot()
+		sk.runCRInformers(proxy, stopCh, namespace, &[]cache.InformerSynced{}, crsV1, crsV3, k.osArgs, false, crV1, crV3)
+		sess.handlers = regs
 		for _, inf := range gwRun {
 			gwWait.Add(1)
 			go func(inf cache.SharedIndexInformer) {
@@ -132,7 +136,7 @@ func (k *k8s) startNSSession(namespace string, epoch uint64, stopCh chan struct{
 			crV1.Shutdown()
 			crV3.Shutdown()
 			gwWait.Wait()
-		}, proxy, &stampWg)
+		}, sess, &stampWg)
 	}
 	return sess, nil
 }
@@ -172,14 +176,12 @@ func (k k8s) watchNamespacesByLabel(eventChan chan k8ssync.SyncDataEvent, stop c
 		logger.Panic("Caches are not populated due to an underlying error, cannot run the Ingress Controller")
 	}
 
-	for _, obj := range nsInformer.GetStore().List() {
-		ns, ok := obj.(*corev1.Namespace)
-		if !ok || ns == nil {
-			continue
-		}
-		if err := k.sessions.Start(ns.Name); err != nil {
-			logger.Panic(err)
-		}
+	// Handler sync means all initial namespace events have been sent, not
+	// processed. Wait for their Start/Stop calls in SyncData before checking
+	// session readiness. Unlike COMMAND, this barrier does not publish a
+	// configuration while the initial resource caches are still warming up.
+	if !waitForNamespaceEvents(eventChan, stop) {
+		return
 	}
 	if !k.sessions.WaitAllReady(stop) {
 		logger.Panic("Caches are not populated due to an underlying error, cannot run the Ingress Controller")
@@ -205,6 +207,21 @@ func (k k8s) watchNamespacesByLabel(eventChan chan k8ssync.SyncDataEvent, stop c
 			EventProcessed: ep,
 		}
 		<-ep
+	}
+}
+
+func waitForNamespaceEvents(eventChan chan<- k8ssync.SyncDataEvent, stop <-chan struct{}) bool {
+	processed := make(chan struct{})
+	select {
+	case <-stop:
+		return false
+	case eventChan <- k8ssync.SyncDataEvent{SyncType: k8ssync.BARRIER, EventProcessed: processed}:
+	}
+	select {
+	case <-stop:
+		return false
+	case <-processed:
+		return true
 	}
 }
 

--- a/pkg/k8s/watch_bootstrap_test.go
+++ b/pkg/k8s/watch_bootstrap_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 HAProxy Technologies LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"testing"
+	"time"
+
+	k8ssync "github.com/haproxytech/kubernetes-ingress/pkg/k8s/sync"
+)
+
+func TestNamespaceBootstrapBarrierWaitsForProcessing(t *testing.T) {
+	t.Parallel()
+	events := make(chan k8ssync.SyncDataEvent, 2)
+	events <- k8ssync.SyncDataEvent{SyncType: k8ssync.NAMESPACE, Namespace: "app"}
+	stop := make(chan struct{})
+	defer close(stop)
+	result := make(chan bool, 1)
+	go func() { result <- waitForNamespaceEvents(events, stop) }()
+
+	if ev := <-events; ev.SyncType != k8ssync.NAMESPACE {
+		t.Fatalf("barrier overtook namespace event: %s", ev.SyncType)
+	}
+	var barrier k8ssync.SyncDataEvent
+	select {
+	case barrier = <-events:
+	case <-time.After(time.Second):
+		t.Fatal("bootstrap barrier was not queued")
+	}
+	if barrier.SyncType != k8ssync.BARRIER || barrier.EventProcessed == nil {
+		t.Fatalf("expected acknowledgement-only barrier, got %#v", barrier)
+	}
+	select {
+	case <-result:
+		t.Fatal("bootstrap continued before SyncData acknowledged prior events")
+	default:
+	}
+	close(barrier.EventProcessed)
+	select {
+	case ok := <-result:
+		if !ok {
+			t.Fatal("acknowledged bootstrap was cancelled")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("bootstrap did not continue after acknowledgement")
+	}
+}
+
+func TestNamespaceBootstrapBarrierCancellation(t *testing.T) {
+	for _, phase := range []string{"send", "acknowledgement"} {
+		t.Run(phase, func(t *testing.T) {
+			t.Parallel()
+			events := make(chan k8ssync.SyncDataEvent)
+			stop := make(chan struct{})
+			result := make(chan bool, 1)
+			go func() { result <- waitForNamespaceEvents(events, stop) }()
+			if phase == "acknowledgement" {
+				select {
+				case <-events:
+				case <-time.After(time.Second):
+					close(stop)
+					t.Fatal("bootstrap barrier was not queued")
+				}
+			}
+			close(stop)
+			select {
+			case ok := <-result:
+				if ok {
+					t.Fatal("cancelled bootstrap reported success")
+				}
+			case <-time.After(time.Second):
+				t.Fatal("bootstrap did not stop")
+			}
+		})
+	}
+}

--- a/pkg/store/events-cr-backend.go
+++ b/pkg/store/events-cr-backend.go
@@ -20,6 +20,9 @@ import (
 
 func (k *K8s) EventBackendCR(namespace, name string, data *v3.Backend) bool {
 	ns := k.GetNamespace(namespace)
+	if data != nil && k.dropDetachedMutation(ns, ADDED) {
+		return false
+	}
 	if data == nil {
 		delete(ns.CRs.Backends, name)
 		return true

--- a/pkg/store/events-cr-defaults.go
+++ b/pkg/store/events-cr-defaults.go
@@ -20,6 +20,9 @@ import (
 
 func (k *K8s) EventDefaultsCR(namespace, name string, data *v3.Defaults) bool {
 	ns := k.GetNamespace(namespace)
+	if data != nil && k.dropDetachedMutation(ns, ADDED) {
+		return false
+	}
 	if data == nil {
 		delete(ns.CRs.Defaults, name)
 		return true

--- a/pkg/store/events-cr-frontend.go
+++ b/pkg/store/events-cr-frontend.go
@@ -20,6 +20,9 @@ import (
 
 func (k *K8s) EventFrontendCR(namespace, name string, data *v3.Frontend) bool {
 	ns := k.GetNamespace(namespace)
+	if data != nil && k.dropDetachedMutation(ns, ADDED) {
+		return false
+	}
 	if data == nil {
 		delete(ns.CRs.Frontends, name)
 		return true

--- a/pkg/store/events-cr-global.go
+++ b/pkg/store/events-cr-global.go
@@ -20,6 +20,9 @@ import (
 
 func (k *K8s) EventGlobalCR(namespace, name string, data *v3.Global) bool {
 	ns := k.GetNamespace(namespace)
+	if data != nil && k.dropDetachedMutation(ns, ADDED) {
+		return false
+	}
 	if data == nil {
 		delete(ns.CRs.Global, name)
 		return true

--- a/pkg/store/events-cr-tcp.go
+++ b/pkg/store/events-cr-tcp.go
@@ -16,6 +16,9 @@ package store
 
 func (k *K8s) EventTCPCR(namespace, name string, data *TCPs) bool {
 	ns := k.GetNamespace(namespace)
+	if data != nil && k.dropDetachedMutation(ns, data.Status) {
+		return false
+	}
 
 	updateRequired := false
 	switch data.Status {
@@ -117,6 +120,12 @@ func (k *K8s) checkCollisionsAllNamespaces() {
 func (k *K8s) tcpsAllNamespaces() TCPResourceList {
 	allTCPs := make(TCPResourceList, 0)
 	for _, ns := range k.Namespaces {
+		if k.NamespacesAccess.LabelSelectorActive && !ns.Relevant {
+			continue
+		}
+		if ns.CRs == nil {
+			continue
+		}
 		for _, v := range ns.CRs.TCPsPerCR {
 			allTCPs = append(allTCPs, v.Items...)
 		}

--- a/pkg/store/events-gateway.go
+++ b/pkg/store/events-gateway.go
@@ -54,6 +54,9 @@ func (k *K8s) EventGatewayClass(data *GatewayClass) (updateRequired bool) {
 }
 
 func (k *K8s) EventGateway(ns *Namespace, data *Gateway) (updateRequired bool) {
+	if k.dropDetachedMutation(ns, data.Status) {
+		return false
+	}
 	switch data.Status {
 	case ADDED:
 		if previous := ns.Gateways[data.Name]; previous != nil {
@@ -89,6 +92,9 @@ func (k *K8s) EventGateway(ns *Namespace, data *Gateway) (updateRequired bool) {
 }
 
 func (k *K8s) EventTCPRoute(ns *Namespace, data *TCPRoute) (updateRequired bool) {
+	if k.dropDetachedMutation(ns, data.Status) {
+		return false
+	}
 	switch data.Status {
 	case ADDED:
 		if previous := ns.TCPRoutes[data.Name]; previous != nil {
@@ -125,6 +131,9 @@ func (k *K8s) EventTCPRoute(ns *Namespace, data *TCPRoute) (updateRequired bool)
 }
 
 func (k *K8s) EventReferenceGrant(ns *Namespace, data *ReferenceGrant) (updateRequired bool) {
+	if k.dropDetachedMutation(ns, data.Status) {
+		return false
+	}
 	switch data.Status {
 	case ADDED:
 		if previous := ns.ReferenceGrants[data.Name]; previous != nil {

--- a/pkg/store/events.go
+++ b/pkg/store/events.go
@@ -27,8 +27,15 @@ func (k *K8s) EventNamespace(ns *Namespace, data *Namespace) (updateRequired boo
 	updateRequired = false
 	switch data.Status {
 	case ADDED:
+		if k.NamespacesAccess.LabelSelectorActive {
+			k.NamespacesAccess.Selected[data.Name] = struct{}{}
+		}
+		_, existed := k.Namespaces[data.Name]
 		nsStore := k.GetNamespace(data.Name)
 		nsStore.Labels = utils.CopyMap(data.Labels)
+		if k.NamespacesAccess.LabelSelectorActive && !existed {
+			nsStore.Relevant = false
+		}
 		updateRequired = true
 	case MODIFIED:
 		nsStore := k.GetNamespace(data.Name)
@@ -37,6 +44,17 @@ func (k *K8s) EventNamespace(ns *Namespace, data *Namespace) (updateRequired boo
 			nsStore.Labels = utils.CopyMap(data.Labels)
 		}
 	case DELETED:
+		if k.NamespacesAccess.LabelSelectorActive {
+			k.unselectNamespace(data.Name)
+			nsStore, ok := k.Namespaces[data.Name]
+			if ok {
+				nsStore.Relevant = false
+				k.teardownNamespaceResources(nsStore)
+				delete(k.Namespaces, data.Name)
+				updateRequired = true
+			}
+			return updateRequired
+		}
 		_, ok := k.Namespaces[data.Name]
 		if ok {
 			delete(k.Namespaces, data.Name)
@@ -46,6 +64,66 @@ func (k *K8s) EventNamespace(ns *Namespace, data *Namespace) (updateRequired boo
 		}
 	}
 	return updateRequired
+}
+
+func (k *K8s) unselectNamespace(name string) {
+	if !k.NamespacesAccess.LabelSelectorActive {
+		return
+	}
+	delete(k.NamespacesAccess.Selected, name)
+}
+
+func (k *K8s) teardownNamespaceResources(nsStore *Namespace) {
+	if nsStore == nil {
+		return
+	}
+	ingresses := make([]*Ingress, 0, len(nsStore.Ingresses))
+	for _, ing := range nsStore.Ingresses {
+		ingresses = append(ingresses, ing)
+	}
+	for _, ing := range ingresses {
+		ing.Status = DELETED
+		k.EventIngress(nsStore, ing, "", "")
+	}
+	if k.publishServiceNS == nsStore.Name && k.publishServiceName != "" {
+		if svc, ok := nsStore.Services[k.publishServiceName]; ok {
+			svc.Status = DELETED
+			k.EventPublishService(nsStore, svc)
+		} else {
+			k.PublishServiceAddresses = nil
+			k.UpdateAllIngresses = true
+		}
+	}
+	if nsStore.CRs != nil {
+		tcps := make([]*TCPs, 0, len(nsStore.CRs.TCPsPerCR))
+		for _, tcp := range nsStore.CRs.TCPsPerCR {
+			tcps = append(tcps, tcp)
+		}
+		for _, tcp := range tcps {
+			tcp.Status = DELETED
+			k.EventTCPCR(nsStore.Name, tcp.Name, tcp)
+		}
+		for name := range nsStore.CRs.Global {
+			k.EventGlobalCR(nsStore.Name, name, nil)
+		}
+		for name := range nsStore.CRs.Defaults {
+			k.EventDefaultsCR(nsStore.Name, name, nil)
+		}
+		for name := range nsStore.CRs.Backends {
+			k.EventBackendCR(nsStore.Name, name, nil)
+		}
+		for name := range nsStore.CRs.Frontends {
+			k.EventFrontendCR(nsStore.Name, name, nil)
+		}
+	}
+	clear(nsStore.Services)
+	clear(nsStore.Secret)
+	clear(nsStore.Endpoints)
+	clear(nsStore.HAProxyRuntime)
+	clear(nsStore.HAProxyRuntimeStandalone)
+	clear(nsStore.Gateways)
+	clear(nsStore.TCPRoutes)
+	clear(nsStore.ReferenceGrants)
 }
 
 func (k *K8s) EventIngressClass(data *IngressClass) (updateRequired bool) {
@@ -62,11 +140,21 @@ func (k *K8s) EventIngressClass(data *IngressClass) (updateRequired bool) {
 func (k *K8s) EventIngress(ns *Namespace, data *Ingress, uid types.UID, resourceVersion string) (updateRequired bool) {
 	updateRequired = true
 
+	if k.dropDetachedMutation(ns, data.Status) {
+		return false
+	}
+
 	if data.Status == DELETED {
 		delete(ns.Ingresses, data.Name)
 		for _, rule := range data.Rules {
 			for _, path := range rule.Paths {
-				k.IngressesByService[path.SvcNamespace+"/"+path.SvcName].Remove(data)
+				key := path.SvcNamespace + "/" + path.SvcName
+				if set := k.IngressesByService[key]; set != nil {
+					set.Remove(data)
+					if k.NamespacesAccess.LabelSelectorActive && len(set.Items()) == 0 {
+						delete(k.IngressesByService, key)
+					}
+				}
 			}
 		}
 		meta.GetMetaStore().ProcessedResourceVersion.Delete(data, uid)
@@ -89,7 +177,13 @@ func (k *K8s) EventIngress(ns *Namespace, data *Ingress, uid types.UID, resource
 
 			for _, rule := range oldIngress.Rules {
 				for _, path := range rule.Paths {
-					k.IngressesByService[path.SvcNamespace+"/"+path.SvcName].Remove(data)
+					key := path.SvcNamespace + "/" + path.SvcName
+					if set := k.IngressesByService[key]; set != nil {
+						set.Remove(data)
+						if k.NamespacesAccess.LabelSelectorActive && len(set.Items()) == 0 {
+							delete(k.IngressesByService, key)
+						}
+					}
 				}
 			}
 		}
@@ -147,6 +241,9 @@ func getEndpoints(slices map[string]*Endpoints) (endpoints map[string]RuntimeEnd
 }
 
 func (k *K8s) EventEndpoints(ns *Namespace, data *Endpoints, syncHAproxySrvs func(backend *RuntimeBackend) error) (updateRequired bool) {
+	if k.dropDetachedMutation(ns, data.Status) {
+		return false
+	}
 	if _, ok := ns.Endpoints[data.Service]; !ok {
 		ns.Endpoints[data.Service] = make(map[string]*Endpoints)
 	}
@@ -225,6 +322,9 @@ func (k *K8s) EventEndpoints(ns *Namespace, data *Endpoints, syncHAproxySrvs fun
 }
 
 func (k *K8s) EventService(ns *Namespace, data *Service) (updateRequired bool) {
+	if k.dropDetachedMutation(ns, data.Status) {
+		return false
+	}
 	updateRequired = false
 	switch data.Status {
 	case MODIFIED:
@@ -313,6 +413,9 @@ func (k *K8s) EventConfigMap(ns *Namespace, data *ConfigMap) (updateRequired boo
 }
 
 func (k *K8s) EventSecret(ns *Namespace, data *Secret) (updateRequired bool) {
+	if k.dropDetachedMutation(ns, data.Status) {
+		return false
+	}
 	updateRequired = false
 	switch data.Status {
 	case MODIFIED:
@@ -373,6 +476,9 @@ func (k *K8s) EventPod(podEvent PodEvent) (updateRequired bool) {
 }
 
 func (k *K8s) EventPublishService(ns *Namespace, data *Service) (updateRequired bool) {
+	if k.dropDetachedMutation(ns, data.Status) {
+		return false
+	}
 	updateRequired = false
 	switch data.Status {
 	case MODIFIED:

--- a/pkg/store/events_namespace_selector_test.go
+++ b/pkg/store/events_namespace_selector_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/haproxytech/client-native/v6/models"
 	v3 "github.com/haproxytech/kubernetes-ingress/crs/api/ingress/v3"
+	rc "github.com/haproxytech/kubernetes-ingress/pkg/reference-counter"
 	"github.com/haproxytech/kubernetes-ingress/pkg/utils"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -115,6 +116,12 @@ func TestSelectorUnmatchRemovesStoreAndIndexes(t *testing.T) {
 	k.EventSecret(ns, &Secret{Namespace: "app", Name: "tls", Status: ADDED})
 
 	k.EventTCPCR("app", "tcp", selectorTCP("app", "tcp", "fe-app", 8000))
+	storedTCP := k.Namespaces["app"].CRs.TCPsPerCR["tcp"]
+	if storedTCP == nil || len(storedTCP.Items) == 0 {
+		t.Fatal("expected stored TCP CR items")
+	}
+	fe := rc.HaproxyCfgResourceName("tcpcr_app_fe-app")
+	k.FrontendRC.AddOwner(fe, storedTCP.Items[0].Owner())
 
 	if k.IngressesByService["app/svc"] == nil {
 		t.Fatal("expected IngressesByService entry")
@@ -133,6 +140,9 @@ func TestSelectorUnmatchRemovesStoreAndIndexes(t *testing.T) {
 	}
 	if _, ok := k.IngressesByService["app/svc"]; ok {
 		t.Fatal("empty IngressesByService key must be deleted")
+	}
+	if k.FrontendRC.HasOwners(fe) {
+		t.Fatal("selector DELETE must drop TCP frontend owners")
 	}
 }
 

--- a/pkg/store/events_namespace_selector_test.go
+++ b/pkg/store/events_namespace_selector_test.go
@@ -1,0 +1,285 @@
+// Copyright 2019 HAProxy Technologies LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/haproxytech/client-native/v6/models"
+	v3 "github.com/haproxytech/kubernetes-ingress/crs/api/ingress/v3"
+	"github.com/haproxytech/kubernetes-ingress/pkg/utils"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func selectorStore() K8s {
+	return NewK8sStore(utils.OSArgs{NamespaceLabelSelector: "watch=true"})
+}
+
+func addSelectedNamespace(k *K8s, name string) *Namespace {
+	k.EventNamespace(nil, &Namespace{
+		Name:   name,
+		Status: ADDED,
+		Labels: map[string]string{"watch": "true"},
+	})
+	return k.Namespaces[name]
+}
+
+func selectorTCP(ns, name, fe string, port int64) *TCPs {
+	p := port
+	return &TCPs{
+		Name:      name,
+		Namespace: ns,
+		Status:    ADDED,
+		Items: TCPResourceList{
+			{
+				ParentName: name,
+				Namespace:  ns,
+				TCPModel: v3.TCPModel{
+					Name: "item",
+					Frontend: models.Frontend{
+						FrontendBase: models.FrontendBase{Name: fe},
+						Binds: map[string]models.Bind{
+							"bind": {Address: "0.0.0.0", Port: &p},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func selectorIngress(ns, name, svcNs, svcName string) *Ingress {
+	return &Ingress{
+		IngressCore: IngressCore{
+			Namespace:    ns,
+			Name:         name,
+			CreationTime: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			Rules: map[string]*IngressRule{
+				"h": {
+					Host: "app.example",
+					Paths: map[string]*IngressPath{
+						"/": {Path: "/", SvcNamespace: svcNs, SvcName: svcName},
+					},
+				},
+			},
+		},
+		Status: ADDED,
+	}
+}
+
+func TestGetNamespace_WhitelistStillCreatesMissing(t *testing.T) {
+	k := NewK8sStore(utils.OSArgs{NamespaceWhitelist: []string{"app"}})
+	if k.NamespacesAccess.LabelSelectorActive {
+		t.Fatal("whitelist must keep selector inactive")
+	}
+	ns := k.GetNamespace("missing")
+	if _, ok := k.Namespaces["missing"]; !ok {
+		t.Fatal("non-selector GetNamespace must insert")
+	}
+	if ns.Name != "missing" {
+		t.Fatalf("name = %q", ns.Name)
+	}
+}
+
+func TestGetNamespace_DefaultStillCreatesMissing(t *testing.T) {
+	k := NewK8sStore(utils.OSArgs{})
+	k.GetNamespace("default")
+	if _, ok := k.Namespaces["default"]; !ok {
+		t.Fatal("default GetNamespace must insert")
+	}
+}
+
+func TestSelectorUnmatchRemovesStoreAndIndexes(t *testing.T) {
+	k := selectorStore()
+	ns := addSelectedNamespace(&k, "app")
+	if !k.MarkNamespaceReady("app") {
+		t.Fatal("MarkNamespaceReady")
+	}
+
+	ing := selectorIngress("app", "web", "app", "svc")
+	k.EventIngress(ns, ing, types.UID("ing-1"), "1")
+	k.EventService(ns, &Service{Namespace: "app", Name: "svc", Status: ADDED})
+	k.EventSecret(ns, &Secret{Namespace: "app", Name: "tls", Status: ADDED})
+
+	k.EventTCPCR("app", "tcp", selectorTCP("app", "tcp", "fe-app", 8000))
+
+	if k.IngressesByService["app/svc"] == nil {
+		t.Fatal("expected IngressesByService entry")
+	}
+
+	k.EventNamespace(ns, &Namespace{Name: "app", Status: DELETED})
+
+	if _, ok := k.Namespaces["app"]; ok {
+		t.Fatal("selector DELETE must drop the namespace from the store")
+	}
+	if _, ok := k.NamespacesAccess.Selected["app"]; ok {
+		t.Fatal("selector DELETE must unselect")
+	}
+	if set := k.IngressesByService["app/svc"]; set != nil && len(set.Items()) > 0 {
+		t.Fatalf("IngressesByService leftover: %#v", set.Items())
+	}
+	if _, ok := k.IngressesByService["app/svc"]; ok {
+		t.Fatal("empty IngressesByService key must be deleted")
+	}
+}
+
+func TestSelectorUnmatchDoesNotResurrectOnLookup(t *testing.T) {
+	k := selectorStore()
+	addSelectedNamespace(&k, "app")
+	k.EventNamespace(nil, &Namespace{Name: "app", Status: DELETED})
+
+	got := k.GetNamespace("app")
+	if _, ok := k.Namespaces["app"]; ok {
+		t.Fatal("GetNamespace after unmatch must not insert")
+	}
+	if got.CRs == nil || got.Services == nil || got.Ingresses == nil || got.Secret == nil {
+		t.Fatal("detached namespace must have nested maps initialized")
+	}
+}
+
+func TestSelectorLateEventsAfterUnmatchDoNotStick(t *testing.T) {
+	k := selectorStore()
+	addSelectedNamespace(&k, "app")
+	k.EventNamespace(nil, &Namespace{Name: "app", Status: DELETED})
+
+	detached := k.GetNamespace("app")
+	ing := selectorIngress("app", "web", "app", "svc")
+	if k.EventIngress(detached, ing, types.UID("late"), "1") {
+		t.Fatal("late Ingress ADDED on detached ns must be dropped")
+	}
+	if _, ok := k.Namespaces["app"]; ok {
+		t.Fatal("late Ingress must not resurrect namespace")
+	}
+	if k.IngressesByService["app/svc"] != nil {
+		t.Fatal("late Ingress must not write IngressesByService")
+	}
+
+	if k.EventService(detached, &Service{Namespace: "app", Name: "svc", Status: ADDED}) {
+		t.Fatal("late Service ADDED must be dropped")
+	}
+	if k.EventSecret(detached, &Secret{Namespace: "app", Name: "tls", Status: ADDED}) {
+		t.Fatal("late Secret ADDED must be dropped")
+	}
+	if k.EventTCPCR("app", "tcp", &TCPs{Name: "tcp", Namespace: "app", Status: ADDED}) {
+		t.Fatal("late TCP CR ADDED must be dropped")
+	}
+}
+
+func TestSelectorAddedDoesNotResetReady(t *testing.T) {
+	k := selectorStore()
+	addSelectedNamespace(&k, "app")
+	if !k.MarkNamespaceReady("app") {
+		t.Fatal("ready")
+	}
+	k.EventNamespace(nil, &Namespace{
+		Name:   "app",
+		Status: ADDED,
+		Labels: map[string]string{"watch": "true", "extra": "1"},
+	})
+	ns := k.Namespaces["app"]
+	if !ns.Relevant {
+		t.Fatal("resync ADD must not reset Relevant on a Ready namespace")
+	}
+	if ns.Labels["extra"] != "1" {
+		t.Fatalf("labels not updated: %#v", ns.Labels)
+	}
+}
+
+func TestSelectorSkipIngressInConfigUsesIngressNamespace(t *testing.T) {
+	k := selectorStore()
+	addSelectedNamespace(&k, "ready")
+	addSelectedNamespace(&k, "starting")
+	k.MarkNamespaceReady("ready")
+
+	readyNS := k.Namespaces["ready"]
+	k.EventService(readyNS, &Service{Namespace: "ready", Name: "svc", Status: ADDED})
+
+	foreign := selectorIngress("starting", "web", "ready", "svc")
+	k.EventIngress(k.Namespaces["starting"], foreign, types.UID("f"), "1")
+
+	if !k.SkipNamespaceInConfig(k.Namespaces["starting"]) {
+		t.Fatal("starting namespace must be skipped")
+	}
+	if k.SkipNamespaceInConfig(k.Namespaces["ready"]) {
+		t.Fatal("ready namespace must not be skipped")
+	}
+	if !k.SkipIngressInConfig(foreign) {
+		t.Fatal("ingress from starting ns must be skipped even when its backend is in a ready ns")
+	}
+}
+
+func TestSelectorGetSecretTreatsStartingAsMissing(t *testing.T) {
+	k := selectorStore()
+	addSelectedNamespace(&k, "app")
+	k.EventSecret(k.Namespaces["app"], &Secret{Namespace: "app", Name: "tls", Status: ADDED})
+	if _, err := k.GetSecret("app", "tls"); err == nil {
+		t.Fatal("Starting namespace secrets must be treated as missing")
+	}
+	k.MarkNamespaceReady("app")
+	if _, err := k.GetSecret("app", "tls"); err != nil {
+		t.Fatalf("Ready namespace secrets must resolve: %v", err)
+	}
+}
+
+func TestSelectorStartingTCPDoesNotCollideReady(t *testing.T) {
+	k := selectorStore()
+	addSelectedNamespace(&k, "ready")
+	addSelectedNamespace(&k, "starting")
+	k.MarkNamespaceReady("ready")
+
+	k.EventTCPCR("ready", "tcp-ready", selectorTCP("ready", "tcp-ready", "fe-ready", 8000))
+	k.EventTCPCR("starting", "tcp-start", selectorTCP("starting", "tcp-start", "fe-start", 8000))
+
+	readyTCP := k.Namespaces["ready"].CRs.TCPsPerCR["tcp-ready"]
+	if readyTCP.Items[0].CollisionStatus == ERROR {
+		t.Fatalf("Starting TCP must not mark Ready TCP as colliding: %s", readyTCP.Items[0].Reason)
+	}
+}
+
+func TestNonSelectorNamespaceDeleteDoesNotRunSelectorTeardown(t *testing.T) {
+	k := NewK8sStore(utils.OSArgs{})
+	ns := k.GetNamespace("app")
+	ing := selectorIngress("app", "web", "app", "svc")
+	k.EventIngress(ns, ing, types.UID("1"), "1")
+	k.EventNamespace(ns, &Namespace{Name: "app", Status: DELETED})
+	if _, ok := k.Namespaces["app"]; ok {
+		t.Fatal("namespace map entry should be gone")
+	}
+	// Master does not clean IngressesByService on namespace DELETE.
+	if k.IngressesByService["app/svc"] == nil {
+		t.Fatal("non-selector DELETE must not run selector teardown of IngressesByService")
+	}
+}
+
+func TestSelectorPublishServiceClearedOnUnmatch(t *testing.T) {
+	k := NewK8sStore(utils.OSArgs{
+		NamespaceLabelSelector: "watch=true",
+		PublishService:         "app/pub",
+	})
+	ns := addSelectedNamespace(&k, "app")
+	k.EventService(ns, &Service{Namespace: "app", Name: "pub", Status: ADDED})
+	k.EventPublishService(ns, &Service{Namespace: "app", Name: "pub", Status: ADDED, Addresses: []string{"1.2.3.4"}})
+	if len(k.PublishServiceAddresses) == 0 {
+		t.Fatal("publish addresses should be set")
+	}
+	k.EventNamespace(ns, &Namespace{Name: "app", Status: DELETED})
+	if k.PublishServiceAddresses != nil {
+		t.Fatalf("publish addresses leftover: %v", k.PublishServiceAddresses)
+	}
+	if !k.UpdateAllIngresses {
+		t.Fatal("unmatch of publish service must set UpdateAllIngresses")
+	}
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -17,6 +17,7 @@ package store
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/haproxytech/client-native/v6/models"
 	v3 "github.com/haproxytech/kubernetes-ingress/crs/api/ingress/v3"
@@ -67,13 +68,17 @@ type K8s struct {
 	FrontendRC                   *rc.ResourceCounter
 	GatewayControllerName        string
 	PublishServiceAddresses      []string
+	publishServiceNS             string
+	publishServiceName           string
 	UpdateAllIngresses           bool
 	IngressesByService           map[string]*utils.OrderedSet[string, *Ingress] // service fqn -> ingress name -> ingress
 }
 
 type NamespacesWatch struct {
-	Whitelist map[string]struct{}
-	Blacklist map[string]struct{}
+	Whitelist           map[string]struct{}
+	Blacklist           map[string]struct{}
+	Selected            map[string]struct{}
+	LabelSelectorActive bool
 }
 
 type ErrNotFound error
@@ -87,6 +92,7 @@ func NewK8sStore(args utils.OSArgs) K8s {
 		NamespacesAccess: NamespacesWatch{
 			Whitelist: map[string]struct{}{},
 			Blacklist: map[string]struct{}{},
+			Selected:  map[string]struct{}{},
 		},
 		ConfigMaps: ConfigMaps{
 			Main: &ConfigMap{
@@ -120,6 +126,13 @@ func NewK8sStore(args utils.OSArgs) K8s {
 	}
 	for _, namespace := range args.NamespaceBlacklist {
 		store.NamespacesAccess.Blacklist[namespace] = struct{}{}
+	}
+	if args.NamespaceLabelSelectorActive() {
+		store.NamespacesAccess.LabelSelectorActive = true
+	}
+	if parts := strings.Split(args.PublishService, "/"); len(parts) == 2 {
+		store.publishServiceNS = parts[0]
+		store.publishServiceName = parts[1]
 	}
 	return store
 }
@@ -197,15 +210,10 @@ func (k *K8s) Clean() {
 	k.UpdateAllIngresses = false
 }
 
-// GetNamespace returns Namespace. Creates one if not existing
-func (k K8s) GetNamespace(name string) *Namespace {
-	namespace, ok := k.Namespaces[name]
-	if ok {
-		return namespace
-	}
-	newNamespace := &Namespace{
+func newEmptyNamespace(name string, relevant bool) *Namespace {
+	return &Namespace{
 		Name:                     name,
-		Relevant:                 k.isRelevantNamespace(name),
+		Relevant:                 relevant,
 		Endpoints:                make(map[string]map[string]*Endpoints),
 		Services:                 make(map[string]*Service),
 		Ingresses:                make(map[string]*Ingress),
@@ -225,13 +233,63 @@ func (k K8s) GetNamespace(name string) *Namespace {
 		Labels:          make(map[string]string),
 		Status:          ADDED,
 	}
+}
+
+// GetNamespace returns Namespace. Creates one if not existing, except when
+// label-selector mode is active and the name is not currently selected.
+func (k K8s) GetNamespace(name string) *Namespace {
+	namespace, ok := k.Namespaces[name]
+	if ok {
+		return namespace
+	}
+	if k.NamespacesAccess.LabelSelectorActive {
+		if _, selected := k.NamespacesAccess.Selected[name]; !selected {
+			return newEmptyNamespace(name, false)
+		}
+		newNamespace := newEmptyNamespace(name, false)
+		k.Namespaces[name] = newNamespace
+		return newNamespace
+	}
+	newNamespace := newEmptyNamespace(name, k.isRelevantNamespace(name))
 	k.Namespaces[name] = newNamespace
 	return newNamespace
 }
 
+// MarkNamespaceReady marks a selected namespace as ready for config generation.
+func (k *K8s) MarkNamespaceReady(name string) bool {
+	if !k.NamespacesAccess.LabelSelectorActive {
+		return false
+	}
+	if _, ok := k.NamespacesAccess.Selected[name]; !ok {
+		return false
+	}
+	ns, ok := k.Namespaces[name]
+	if !ok {
+		return false
+	}
+	if ns.Relevant {
+		return false
+	}
+	ns.Relevant = true
+	k.checkCollisionsAllNamespaces()
+	return true
+}
+
+func (k K8s) selectorNamespacePersistent(ns *Namespace) bool {
+	if ns == nil {
+		return false
+	}
+	stored, ok := k.Namespaces[ns.Name]
+	return ok && stored == ns
+}
+
+func (k K8s) dropDetachedMutation(ns *Namespace, status Status) bool {
+	return k.NamespacesAccess.LabelSelectorActive && status != DELETED && !k.selectorNamespacePersistent(ns)
+}
+
 func (k K8s) GetSecret(namespace, name string) (*Secret, error) {
 	ns, ok := k.Namespaces[namespace]
-	if !ok {
+	if !ok || k.configNamespaceMissing(ns) {
 		return nil, fmt.Errorf("secret '%s/%s' does not exist, namespace not found", namespace, name)
 	}
 	secret, secretOK := ns.Secret[name]
@@ -246,7 +304,7 @@ func (k K8s) GetSecret(namespace, name string) (*Secret, error) {
 
 func (k K8s) GetService(namespace, name string) (*Service, error) {
 	ns, nsOk := k.Namespaces[namespace]
-	if !nsOk {
+	if !nsOk || k.configNamespaceMissing(ns) {
 		return nil, fmt.Errorf("service '%s/%s' does not exist, namespace not found", namespace, name)
 	}
 	svc, svcOk := ns.Services[name]
@@ -262,7 +320,7 @@ func (k K8s) GetService(namespace, name string) (*Service, error) {
 // GetEndpoints takes the ns and name of a service and provides a map of endpoints: portName --> *PortEndpoints
 func (k K8s) GetEndpoints(namespace, name string) (endpoints map[string]*PortEndpoints, err error) {
 	ns, nsOk := k.Namespaces[namespace]
-	if !nsOk {
+	if !nsOk || k.configNamespaceMissing(ns) {
 		return nil, fmt.Errorf("service '%s/%s' does not exist, namespace not found", namespace, name)
 	}
 	slices, ok := ns.Endpoints[name]
@@ -288,6 +346,36 @@ func (k K8s) isRelevantNamespace(namespace string) bool {
 	}
 	_, ok := k.NamespacesAccess.Blacklist[namespace]
 	return !ok
+}
+
+func (k K8s) configNamespaceMissing(ns *Namespace) bool {
+	return k.NamespacesAccess.LabelSelectorActive && (ns == nil || !ns.Relevant)
+}
+
+// SkipNamespaceInConfig reports whether selector mode must omit this namespace
+// from HAProxy generation. Non-selector callers always get false so existing
+// Relevant checks keep their original meaning.
+func (k K8s) SkipNamespaceInConfig(ns *Namespace) bool {
+	if !k.NamespacesAccess.LabelSelectorActive {
+		return false
+	}
+	return ns == nil || !ns.Relevant
+}
+
+// SkipIngressInConfig reports whether selector mode must omit this Ingress,
+// including when it is reached through another namespace's service index.
+func (k K8s) SkipIngressInConfig(ing *Ingress) bool {
+	if ing == nil {
+		return true
+	}
+	if ing.Faked {
+		return false
+	}
+	if !k.NamespacesAccess.LabelSelectorActive {
+		return false
+	}
+	ns, ok := k.Namespaces[ing.Namespace]
+	return !ok || !ns.Relevant
 }
 
 func (k K8s) IsIngressClassSupported(ingressClass, controllerClass string, allowEmptyClass bool) bool {

--- a/pkg/utils/flags.go
+++ b/pkg/utils/flags.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 // NamespaceValue used to automatically distinct namespace/name string
@@ -90,6 +92,7 @@ type OSArgs struct {
 	Version                           []bool         `short:"v" long:"version" description:"version"`
 	NamespaceWhitelist                []string       `long:"namespace-whitelist" description:"whitelisted namespaces"`
 	NamespaceBlacklist                []string       `long:"namespace-blacklist" description:"blacklisted namespaces"`
+	NamespaceLabelSelector            string         `long:"namespace-label-selector" description:"label selector to dynamically watch namespaces. Ignored if --namespace-whitelist or --namespace-blacklist is set"`
 	Help                              []bool         `short:"h" long:"help" description:"show this help message"`
 	LocalPeerPort                     int64          `long:"localpeer-port" default:"10000" description:"port to listen on for local peer"`
 	StatsBindPort                     int64          `long:"stats-bind-port" default:"1024" description:"port to listen on for stats page"`
@@ -128,4 +131,47 @@ type OSArgs struct {
 	DisableIngressStatusUpdate        bool           `long:"disable-ingress-status-update" description:"If true, disables updating the status field of Ingress resources"`
 	EnableCustomAnnotationsOnIngress  bool           `long:"enable-custom-annotations-on-ingress" description:"allow custom user annotations on ingress"`
 	CustomValidationRules             NamespaceValue `long:"custom-validation-rules" description:"custom validation rules object" default:""`
+}
+
+// NamespaceLabelSelectorActive reports whether --namespace-label-selector is
+// the active namespace filter. Whitelist and blacklist take precedence.
+func (a OSArgs) NamespaceLabelSelectorActive() bool {
+	return strings.TrimSpace(a.NamespaceLabelSelector) != "" &&
+		len(a.NamespaceWhitelist) == 0 &&
+		len(a.NamespaceBlacklist) == 0
+}
+
+// NamespaceLabelSelectorIgnored reports that a selector was set but will not
+// be used because whitelist or blacklist is also set.
+func (a OSArgs) NamespaceLabelSelectorIgnored() bool {
+	return strings.TrimSpace(a.NamespaceLabelSelector) != "" &&
+		(len(a.NamespaceWhitelist) > 0 || len(a.NamespaceBlacklist) > 0)
+}
+
+// NamespaceLabelSelectorCanonical returns the trimmed selector string used for
+// labels.Parse and the Namespace informer. Empty when the selector is inactive.
+func (a OSArgs) NamespaceLabelSelectorCanonical() string {
+	if !a.NamespaceLabelSelectorActive() {
+		return ""
+	}
+	return strings.TrimSpace(a.NamespaceLabelSelector)
+}
+
+// ValidateNamespaceLabelSelector parses --namespace-label-selector when it is
+// the active filter. Whitespace-only or invalid selectors fail startup.
+func (a OSArgs) ValidateNamespaceLabelSelector() error {
+	if len(a.NamespaceWhitelist) > 0 || len(a.NamespaceBlacklist) > 0 {
+		return nil
+	}
+	if a.NamespaceLabelSelector == "" {
+		return nil
+	}
+	sel := strings.TrimSpace(a.NamespaceLabelSelector)
+	if sel == "" {
+		return fmt.Errorf("invalid --namespace-label-selector %q: selector must not be empty or whitespace-only", a.NamespaceLabelSelector)
+	}
+	if _, err := labels.Parse(sel); err != nil {
+		return fmt.Errorf("invalid --namespace-label-selector %q: %w", a.NamespaceLabelSelector, err)
+	}
+	return nil
 }

--- a/pkg/utils/flags_test.go
+++ b/pkg/utils/flags_test.go
@@ -1,0 +1,129 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jessevdk/go-flags"
+)
+
+func TestOSArgs_NamespaceLabelSelectorActive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args OSArgs
+		want bool
+	}{
+		{name: "unset", args: OSArgs{}, want: false},
+		{name: "selector only", args: OSArgs{NamespaceLabelSelector: "watch=true"}, want: true},
+		{name: "whitespace selector is not active", args: OSArgs{NamespaceLabelSelector: "  "}, want: false},
+		{
+			name: "whitelist wins",
+			args: OSArgs{NamespaceLabelSelector: "watch=true", NamespaceWhitelist: []string{"app"}},
+			want: false,
+		},
+		{
+			name: "blacklist wins",
+			args: OSArgs{NamespaceLabelSelector: "watch=true", NamespaceBlacklist: []string{"kube-system"}},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.args.NamespaceLabelSelectorActive(); got != tt.want {
+				t.Errorf("NamespaceLabelSelectorActive() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOSArgs_ValidateNamespaceLabelSelector(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		args    OSArgs
+		wantErr bool
+	}{
+		{name: "empty is ok", args: OSArgs{}},
+		{name: "equality selector", args: OSArgs{NamespaceLabelSelector: "watch=true"}},
+		{name: "set-based selector", args: OSArgs{NamespaceLabelSelector: "env in (prod,staging)"}},
+		{name: "invalid selector", args: OSArgs{NamespaceLabelSelector: "watch==="}, wantErr: true},
+		{name: "whitespace only", args: OSArgs{NamespaceLabelSelector: "   "}, wantErr: true},
+		{
+			name: "invalid ignored when whitelist set",
+			args: OSArgs{NamespaceLabelSelector: "watch===", NamespaceWhitelist: []string{"app"}},
+		},
+		{
+			name: "invalid ignored when blacklist set",
+			args: OSArgs{NamespaceLabelSelector: "   ", NamespaceBlacklist: []string{"kube-system"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.args.ValidateNamespaceLabelSelector()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateNamespaceLabelSelector() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil && tt.wantErr && !strings.Contains(err.Error(), "--namespace-label-selector") {
+				t.Errorf("error %q should name --namespace-label-selector", err)
+			}
+		})
+	}
+}
+
+func TestOSArgs_NamespaceLabelSelectorCanonicalAndIgnored(t *testing.T) {
+	t.Parallel()
+
+	active := OSArgs{NamespaceLabelSelector: "  watch=true  "}
+	if got := active.NamespaceLabelSelectorCanonical(); got != "watch=true" {
+		t.Errorf("Canonical() = %q, want watch=true", got)
+	}
+	if active.NamespaceLabelSelectorIgnored() {
+		t.Fatal("selector-only must not be reported as ignored")
+	}
+
+	ignored := OSArgs{NamespaceLabelSelector: "watch=true", NamespaceWhitelist: []string{"app"}}
+	if ignored.NamespaceLabelSelectorCanonical() != "" {
+		t.Errorf("Canonical() with whitelist must be empty")
+	}
+	if !ignored.NamespaceLabelSelectorIgnored() {
+		t.Fatal("whitelist + selector must be ignored")
+	}
+}
+
+func TestOSArgs_ParseNamespaceLabelSelectorFlag(t *testing.T) {
+	t.Parallel()
+
+	var args OSArgs
+	parser := flags.NewParser(&args, flags.IgnoreUnknown)
+	_, err := parser.ParseArgs([]string{"--namespace-label-selector=watch=true"})
+	if err != nil {
+		t.Fatalf("ParseArgs: %v", err)
+	}
+	if !args.NamespaceLabelSelectorActive() {
+		t.Fatal("parsed --namespace-label-selector should be active")
+	}
+	if err := args.ValidateNamespaceLabelSelector(); err != nil {
+		t.Fatalf("ValidateNamespaceLabelSelector: %v", err)
+	}
+
+	var withWhitelist OSArgs
+	parser = flags.NewParser(&withWhitelist, flags.IgnoreUnknown)
+	_, err = parser.ParseArgs([]string{
+		"--namespace-label-selector=watch=true",
+		"--namespace-whitelist=app",
+	})
+	if err != nil {
+		t.Fatalf("ParseArgs whitelist: %v", err)
+	}
+	if withWhitelist.NamespaceLabelSelectorActive() {
+		t.Fatal("whitelist must take precedence over selector")
+	}
+	if !withWhitelist.NamespaceLabelSelectorIgnored() {
+		t.Fatal("selector present with whitelist must be ignored")
+	}
+}


### PR DESCRIPTION
Hello,

This PR adds support for `--namespace-label-selector`, as discussed in #847. Thank you for considering it.

### Motivation

`--namespace-whitelist` and `--namespace-blacklist` are name-based and fixed at startup. In clusters where namespaces are created or reassigned regularly, keeping a whitelist in sync currently means changing controller arguments and restarting.

A Kubernetes label selector would let membership follow namespace labels without a restart.

### Behaviour

- Only namespaces that currently match the selector are watched.
- Labeling a namespace starts a per-namespace watch.
- Removing or changing the label so it no longer matches stops the watch and drops that namespace from the generated HAProxy configuration.
- `--namespace-whitelist` and `--namespace-blacklist` are unchanged. If either is set, the selector is ignored (a warning is logged).

The controller namespace, publish-service namespace, and default certificate namespace are not selected automatically; they need to match the selector when those features are used.

### Testing

- Unit tests in `pkg/k8s`, `pkg/store`, `pkg/utils`, and `pkg/controller`
- Sequential e2e suite `deploy/tests/e2e/namespace-selector` (`TestNamespaceSelectorSuite`): label/unlabel/relabel, two matching namespaces, bootstrap after restart, namespace deletion, TCP CR, and whitelist/blacklist precedence

I would be happy to adjust the design or tests based on your feedback.

Closes #847